### PR TITLE
fix MQTT problem and add TX channel switch to send loop 

### DIFF
--- a/tools/esp8266/app.cpp
+++ b/tools/esp8266/app.cpp
@@ -124,8 +124,8 @@ void app::setup(uint32_t timeout) {
 
 
         // mqtt
-        char mqttAddr[MQTT_ADDR_LEN];
         uint16_t mqttPort;
+        char mqttAddr[MQTT_ADDR_LEN];
         char mqttUser[MQTT_USER_LEN];
         char mqttPwd[MQTT_PWD_LEN];
         char mqttTopic[MQTT_TOPIC_LEN];
@@ -209,9 +209,9 @@ void app::loop(void) {
     yield();
 
     if(checkTicker(&mRxTicker, 5)) {
-        DPRINTLN(DBG_DEBUG, F("app_loops =") + String(app_loops));
+        //DPRINTLN(DBG_VERBOSE, F("app_loops =") + String(app_loops));
         app_loops=0;
-        DPRINT(DBG_DEBUG, F("a"));
+        DPRINT(DBG_VERBOSE, F("a"));
 
         bool rxRdy = mSys->Radio.switchRxCh();
 
@@ -222,7 +222,8 @@ void app::loop(void) {
             if(mSys->Radio.checkPaketCrc(p->packet, &len, p->rxCh)) {
                 // process buffer only on first occurrence
                 if(mSerialDebug) {
-                    DPRINT(DBG_DEBUG, "Received " + String(len) + " bytes channel " + String(p->rxCh) + ": ");
+                    DPRINT(DBG_INFO, "RX " + String(len) + "B Ch" + String(p->rxCh) + " | ");
+
                     mSys->Radio.dumpBuf(NULL, p->packet, len);
                 }
                 mFrameCnt++;

--- a/tools/esp8266/mqtt.h
+++ b/tools/esp8266/mqtt.h
@@ -16,6 +16,7 @@ class mqtt {
             mClient     = new PubSubClient(mEspClient);
             mAddressSet = false;
 
+            memset(mAddr,  0, MQTT_ADDR_LEN);
             memset(mUser,  0, MQTT_USER_LEN);
             memset(mPwd,   0, MQTT_PWD_LEN);
             memset(mTopic, 0, MQTT_TOPIC_LEN);
@@ -23,13 +24,14 @@ class mqtt {
 
         ~mqtt() { }
 
-        void setup(const char *broker, const char *topic, const char *user, const char *pwd, uint16_t port) {
+        void setup(const char *addr, const char *topic, const char *user, const char *pwd, uint16_t port) {
             DPRINTLN(DBG_VERBOSE, F("mqtt.h:setup"));
             mAddressSet = true;
-            mClient->setServer(broker, port);
+            mClient->setServer(addr, port);
             mClient->setBufferSize(MQTT_MAX_PACKET_SIZE);
 
             mPort = port;
+            snprintf(mAddr, MQTT_ADDR_LEN, "%s", addr);
             snprintf(mUser, MQTT_USER_LEN, "%s", user);
             snprintf(mPwd, MQTT_PWD_LEN, "%s", pwd);
             snprintf(mTopic, MQTT_TOPIC_LEN, "%s", topic);
@@ -56,6 +58,11 @@ class mqtt {
             if(doRecon)
                 reconnect();
             return mClient->connected();
+        }
+
+        char *getAddr(void) {
+            //DPRINTLN(DBG_VERBOSE, F("mqtt.h:getAddr"));
+            return mAddr;
         }
 
         char *getUser(void) {
@@ -88,10 +95,12 @@ class mqtt {
         void reconnect(void) {
             //DPRINTLN(DBG_VERBOSE, F("mqtt.h:reconnect"));
             if(!mClient->connected()) {
-                if((strlen(mUser) > 0) && (strlen(mPwd) > 0))
-                    mClient->connect(DEF_DEVICE_NAME, mUser, mPwd);
-                else
-                    mClient->connect(DEF_DEVICE_NAME);
+                if(strlen(mAddr) > 0) {
+                    if((strlen(mUser) > 0) && (strlen(mPwd) > 0))
+                        mClient->connect(mAddr, mUser, mPwd);
+                    else
+                        mClient->connect(mAddr);
+                }
             }
         }
 
@@ -100,6 +109,7 @@ class mqtt {
 
         bool mAddressSet;
         uint16_t mPort;
+        char mAddr[MQTT_ADDR_LEN];
         char mUser[MQTT_USER_LEN];
         char mPwd[MQTT_PWD_LEN];
         char mTopic[MQTT_TOPIC_LEN];

--- a/tools/esp8266/platformio.ini
+++ b/tools/esp8266/platformio.ini
@@ -1,3 +1,13 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
 [platformio]
 src_dir = .
 
@@ -5,33 +15,67 @@ src_dir = .
 platform = espressif8266
 framework = arduino
 board = d1_mini
-monitor_speed = 115200
 board_build.f_cpu = 80000000L
-;build_flags = -DDEBUG_ESP_PORT=Serial
 
-lib_deps =
-  nrf24/RF24@1.4.2
+; ;;;;; Possible Debug options ;;;;;;
+; https://docs.platformio.org/en/latest/platforms/espressif8266.html#debug-level
+;build_flags = -DDEBUG_ESP_PORT=Serial
+    ;-DDEBUG_ESP_CORE 
+	;-DDEBUG_ESP_WIFI 
+	;-DDEBUG_ESP_HTTP_CLIENT 
+	;-DDEBUG_ESP_HTTP_SERVER 
+	;-DDEBUG_ESP_OOM 
+
+monitor_speed = 115200
+monitor_filters = 
+	;default   ; Remove typical terminal control codes from input
+	time      ; Add timestamp with milliseconds for each new line
+    ;log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
+
+lib_deps = 
+	nrf24/RF24@1.4.2
 	paulstoffregen/Time@^1.6.1
 	knolleary/PubSubClient@^2.8
-  bblanchon/ArduinoJson@^6.19.4
-  ;esp8266/DNSServer@1.1.0
-  ;esp8266/EEPROM@^1.0
-  ;esp8266/ESP8266HTTPUpdateServer@^1.0
-  ;esp8266/ESP8266WebServer@^1.0
-  ;esp8266/ESP8266WiFi@^1.0
-  ;esp8266/SPI@1.0
-  ;esp8266/Ticker@^1.0
+	bblanchon/ArduinoJson@^6.19.4
+    ;esp8266/DNSServer@1.1.0
+    ;esp8266/EEPROM@^1.0
+    ;esp8266/ESP8266HTTPUpdateServer@^1.0
+    ;esp8266/ESP8266WebServer@^1.0
+    ;esp8266/ESP8266WiFi@^1.0
+    ;esp8266/SPI@1.0
+    ;esp8266/Ticker@^1.0
 
 [env:node_mcu_v2]
 platform = espressif8266
 framework = arduino
 board = nodemcuv2
-monitor_speed = 115200
 board_build.f_cpu = 80000000L
+
+; ;;;;; Possible Debug options ;;;;;;
+; https://docs.platformio.org/en/latest/platforms/espressif8266.html#debug-level
+;build_flags = -DDEBUG_ESP_PORT=Serial
+    ;-DDEBUG_ESP_CORE 
+	;-DDEBUG_ESP_WIFI 
+	;-DDEBUG_ESP_HTTP_CLIENT 
+	;-DDEBUG_ESP_HTTP_SERVER 
+	;-DDEBUG_ESP_OOM 
+
+monitor_speed = 115200
+monitor_filters = 
+	;default   ; Remove typical terminal control codes from input
+	time       ; Add timestamp with milliseconds for each new line
+    ;log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
 upload_port = /dev/ttyUSB0
 
-lib_deps =
-  nrf24/RF24@1.4.2
+lib_deps = 
+	nrf24/RF24@1.4.2
 	paulstoffregen/Time@^1.6.1
 	knolleary/PubSubClient@^2.8
-  bblanchon/ArduinoJson@^6.19.4
+	bblanchon/ArduinoJson@^6.19.4
+    ;esp8266/DNSServer@1.1.0
+    ;esp8266/EEPROM@^1.0
+    ;esp8266/ESP8266HTTPUpdateServer@^1.0
+    ;esp8266/ESP8266WebServer@^1.0
+    ;esp8266/ESP8266WiFi@^1.0
+    ;esp8266/SPI@1.0
+    ;esp8266/Ticker@^1.0


### PR DESCRIPTION
As analyzed and debugged with @baloo the problem in #106 is caused by handing temporary Strings to PubSubClient in lines 92 and 94.
https://github.com/grindylow/ahoy/blob/c35c86210f8507be7352ead73c02e5855f3f9d63/tools/esp8266/mqtt.h#L88-L96 

PubSubClient keeps a reference (in this->domain) to this String and upon publishing to a topic tries to access that short-lived memory location. The MQTT Broker can not be found when doing the reconnect, as the random name from memory cannot be resolved via mDNS.

The mRfChLst[4] in hmRadio.h can be used by two indices mTxIdx and mRxIdx by adding a matching getTxNxtChannel method too.
https://github.com/grindylow/ahoy/blob/c35c86210f8507be7352ead73c02e5855f3f9d63/tools/esp8266/hmRadio.h#L64-L69
https://github.com/grindylow/ahoy/blob/c35c86210f8507be7352ead73c02e5855f3f9d63/tools/esp8266/hmRadio.h#L293-L298