### PR TITLE
Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tools/esp8266/binaries
 *.db
 *.suo
 *.ipch
+tools/esp8266/.vscode/extensions.json

--- a/tools/esp8266/app.h
+++ b/tools/esp8266/app.h
@@ -51,7 +51,7 @@ class app : public Main {
         void setup(uint32_t timeout);
         void loop(void);
         void handleIntr(void);
-        void cbMqtt(const char* topic, byte* payload, unsigned int length);
+        void cbMqtt(char* topic, byte* payload, unsigned int length);
 
         uint8_t app_loops;
         uint8_t getIrqPin(void) {

--- a/tools/esp8266/app.h
+++ b/tools/esp8266/app.h
@@ -71,6 +71,7 @@ class app : public Main {
         void showHoymiles(void);
         void showLiveData(void);
         void showJSON(void);
+        void devControl(void);
 
 
         void saveValues(bool webSend);

--- a/tools/esp8266/app.h
+++ b/tools/esp8266/app.h
@@ -51,6 +51,7 @@ class app : public Main {
         void setup(uint32_t timeout);
         void loop(void);
         void handleIntr(void);
+        void cbMqtt(const char* topic, byte* payload, unsigned int length);
 
         uint8_t app_loops;
         uint8_t getIrqPin(void) {

--- a/tools/esp8266/defines.h
+++ b/tools/esp8266/defines.h
@@ -53,6 +53,7 @@ typedef struct {
 #define INV_CH_CH_NAME_LEN  MAX_NUM_INVERTERS * MAX_NAME_LENGTH * 4 // (4 channels)
 #define INV_INTERVAL_LEN    2                                       // uint16_t
 #define INV_MAX_RTRY_LEN    1                                       // uint8_t
+#define INV_PWR_LIM_LEN     MAX_NUM_INVERTERS * 2                   // uint16_t 
 
 #define PINOUT_LEN          3 // 3 pins: CS, CE, IRQ
 
@@ -89,8 +90,9 @@ typedef struct {
 #define ADDR_INV_CH_NAME    ADDR_INV_CH_PWR    + INV_CH_CH_PWR_LEN
 #define ADDR_INV_INTERVAL   ADDR_INV_CH_NAME   + INV_CH_CH_NAME_LEN
 #define ADDR_INV_MAX_RTRY   ADDR_INV_INTERVAL  + INV_INTERVAL_LEN
+#define ADDR_INV_PWR_LIM    ADDR_INV_MAX_RTRY  + INV_MAX_RTRY_LEN
 
-#define ADDR_MQTT_ADDR      ADDR_INV_MAX_RTRY  + INV_MAX_RTRY_LEN
+#define ADDR_MQTT_ADDR      ADDR_INV_PWR_LIM   + INV_PWR_LIM_LEN
 #define ADDR_MQTT_USER      ADDR_MQTT_ADDR     + MQTT_ADDR_LEN
 #define ADDR_MQTT_PWD       ADDR_MQTT_USER     + MQTT_USER_LEN
 #define ADDR_MQTT_TOPIC     ADDR_MQTT_PWD      + MQTT_PWD_LEN

--- a/tools/esp8266/defines.h
+++ b/tools/esp8266/defines.h
@@ -20,8 +20,8 @@
 // VERSION
 //-------------------------------------
 #define VERSION_MAJOR       0
-#define VERSION_MINOR       4
-#define VERSION_PATCH       26
+#define VERSION_MINOR       5
+#define VERSION_PATCH       1
 
 
 //-------------------------------------

--- a/tools/esp8266/hmInverter.h
+++ b/tools/esp8266/hmInverter.h
@@ -69,6 +69,8 @@ class Inverter {
         uint8_t       type;     // integer which refers to inverter type
         byteAssign_t* assign;   // type of inverter
         uint8_t       listLen;  // length of assignments
+        uint16_t      powerLimit;  // limit power output
+        bool          powerLimitChange; // true if change needed
         serial_u      serial;   // serial number as on barcode
         serial_u      radioId;  // id converted to modbus
         uint8_t       channels; // number of PV channels (1-4)
@@ -79,6 +81,8 @@ class Inverter {
 
         Inverter() {
             ts = 0;
+            powerLimit = -1; // 65535 W Limit -> unlimited
+            powerLimitChange = false;
         }
 
         ~Inverter() {

--- a/tools/esp8266/hmInverter.h
+++ b/tools/esp8266/hmInverter.h
@@ -84,6 +84,7 @@ class Inverter {
             ts = 0;
             powerLimit = -1; // 65535 W Limit -> unlimited
             devControlRequest = false;
+            devControlCmd = 0xff;
         }
 
         ~Inverter() {

--- a/tools/esp8266/hmInverter.h
+++ b/tools/esp8266/hmInverter.h
@@ -70,7 +70,8 @@ class Inverter {
         byteAssign_t* assign;   // type of inverter
         uint8_t       listLen;  // length of assignments
         uint16_t      powerLimit;  // limit power output
-        bool          powerLimitChange; // true if change needed
+        uint8_t       devControlCmd;  // carries the requested cmd
+        bool          devControlRequest; // true if change needed
         serial_u      serial;   // serial number as on barcode
         serial_u      radioId;  // id converted to modbus
         uint8_t       channels; // number of PV channels (1-4)
@@ -82,7 +83,7 @@ class Inverter {
         Inverter() {
             ts = 0;
             powerLimit = -1; // 65535 W Limit -> unlimited
-            powerLimitChange = false;
+            devControlRequest = false;
         }
 
         ~Inverter() {

--- a/tools/esp8266/hmRadio.h
+++ b/tools/esp8266/hmRadio.h
@@ -177,8 +177,8 @@ class HmRadio {
                 }
                 mTxBuf[10 + (++cnt)] = (data >> 8) & 0xff; // 0x01
                 mTxBuf[10 + (++cnt)] = (data     ) & 0xff; // 0x2c
-                // are these two bytes necessary? --> yes it seems so
-                mTxBuf[10 + (++cnt)] = 0x00;
+                // mTxBuf[10 + (++cnt)] = 0x00; // not persistent
+                mTxBuf[10 + (++cnt)] = 0x01; // persistent
                 mTxBuf[10 + (++cnt)] = 0x00;
             }
             // crc control data

--- a/tools/esp8266/hmRadio.h
+++ b/tools/esp8266/hmRadio.h
@@ -166,6 +166,28 @@ class HmRadio {
             return mTxChLst[mTxChIdx];
         }*/
 
+        void sendControlPacket(uint64_t invId, uint16_t data) {
+            DPRINTLN(DBG_VERBOSE, F("hmRadio.h:sendControlPacket"));
+            sendCmdPacket(invId, 0x51, 0x80, false);
+            mTxBuf[10] = 0x0b; // control type --> 0x0b => Type_ActivePowerContr
+            mTxBuf[11] = 0x00;
+            // 4 bytes control data
+            // Power Limit fix point 10 eg. 30 W --> 0d300 = 0x012c
+            mTxBuf[12] = (data >> 8) & 0xff; // 0x01
+            mTxBuf[13] = (data     ) & 0xff; // 0x2c
+            //
+            mTxBuf[14] = 0x00;
+            mTxBuf[15] = 0x00;
+            // crc control data
+            uint16_t crc = crc16(&mTxBuf[10], 6);
+            mTxBuf[16] = (crc >> 8) & 0xff;
+            mTxBuf[17] = (crc     ) & 0xff;
+            // crc over all
+            mTxBuf[18] = crc8(mTxBuf, 18);
+
+            sendPacket(invId, mTxBuf, 19, true);
+        }
+
         void sendTimePacket(uint64_t invId, uint32_t ts) {
             //DPRINTLN(DBG_VERBOSE, F("hmRadio.h:sendTimePacket"));
             sendCmdPacket(invId, 0x15, 0x80, false);

--- a/tools/esp8266/main.cpp
+++ b/tools/esp8266/main.cpp
@@ -71,6 +71,7 @@ void Main::setup(uint32_t timeout) {
 
     mUpdater->setup(mWeb);
     mApActive = startAp;
+    mStActive = !startAp;
 }
 
 
@@ -120,6 +121,10 @@ void Main::loop(void) {
             mHeapStatCnt = 0;
             stats();
         }*/
+    }
+    if (WiFi.status() != WL_CONNECTED) {
+        DPRINTLN(DBG_INFO, "[WiFi]: Connection Lost");
+        mStActive = false;
     }
 }
 

--- a/tools/esp8266/main.h
+++ b/tools/esp8266/main.h
@@ -118,6 +118,7 @@ class Main {
         bool mWifiSettingsValid;
         bool mSettingsValid;
         bool mApActive;
+        bool mStActive;
         ESP8266WebServer *mWeb;
         char mVersion[9];
         char mDeviceName[DEVNAME_LEN];

--- a/tools/esp8266/mqtt.h
+++ b/tools/esp8266/mqtt.h
@@ -99,7 +99,10 @@ class mqtt {
                 else
                     mClient->connect(DEF_DEVICE_NAME);
             }
-            mClient->subscribe("home/huette/powerset");
+            char topic[MQTT_TOPIC_LEN + 13 ]; // "/devcontrol/#" --> + 6 byte
+            // ToDo: "/devcontrol/#" is hardcoded 
+            snprintf(topic, MQTT_TOPIC_LEN + 13, "%s/devcontrol/#", mTopic); 
+            mClient->subscribe(topic); // subscribe to mTopic + "/devcontrol/#"
         }
 
         WiFiClient mEspClient;

--- a/tools/esp8266/mqtt.h
+++ b/tools/esp8266/mqtt.h
@@ -102,6 +102,7 @@ class mqtt {
             char topic[MQTT_TOPIC_LEN + 13 ]; // "/devcontrol/#" --> + 6 byte
             // ToDo: "/devcontrol/#" is hardcoded 
             snprintf(topic, MQTT_TOPIC_LEN + 13, "%s/devcontrol/#", mTopic); 
+            DPRINTLN(DBG_INFO, F("subscribe to ") + String(topic));
             mClient->subscribe(topic); // subscribe to mTopic + "/devcontrol/#"
         }
 

--- a/tools/esp8266/mqtt.h
+++ b/tools/esp8266/mqtt.h
@@ -12,6 +12,8 @@
 
 class mqtt {
     public:
+        PubSubClient *mClient;
+
         mqtt() {
             mClient     = new PubSubClient(mEspClient);
             mAddressSet = false;
@@ -33,6 +35,10 @@ class mqtt {
             snprintf(mUser, MQTT_USER_LEN, "%s", user);
             snprintf(mPwd, MQTT_PWD_LEN, "%s", pwd);
             snprintf(mTopic, MQTT_TOPIC_LEN, "%s", topic);
+        }
+
+        void setCallback(void (*func)(const char* topic, byte* payload, unsigned int length)){
+            mClient->setCallback(func);
         }
 
         void sendMsg(const char *topic, const char *msg) {
@@ -79,25 +85,25 @@ class mqtt {
 
         void loop() {
             //DPRINT(F("m"));
-            //if(!mClient->connected())
-            //    reconnect();
+            if(!mClient->connected())
+                reconnect();
             mClient->loop();
         }
 
     private:
         void reconnect(void) {
-            //DPRINTLN(DBG_VERBOSE, F("mqtt.h:reconnect"));
+            DPRINTLN(DBG_INFO, F("mqtt.h:reconnect"));
             if(!mClient->connected()) {
                 if((strlen(mUser) > 0) && (strlen(mPwd) > 0))
                     mClient->connect(DEF_DEVICE_NAME, mUser, mPwd);
                 else
                     mClient->connect(DEF_DEVICE_NAME);
             }
+            mClient->subscribe("home/huette/powerset");
         }
 
         WiFiClient mEspClient;
-        PubSubClient *mClient;
-
+        
         bool mAddressSet;
         uint16_t mPort;
         char mUser[MQTT_USER_LEN];

--- a/tools/esp8266/platformio.ini
+++ b/tools/esp8266/platformio.ini
@@ -28,7 +28,6 @@ framework = arduino
 board = nodemcuv2
 monitor_speed = 115200
 board_build.f_cpu = 80000000L
-upload_port = /dev/ttyUSB0
 
 lib_deps =
   nrf24/RF24@1.4.2


### PR DESCRIPTION
Hi,

TESTET for HM-1500 (3rd gen)

- devControl commands via MQTT Topic (<YOUR TOPIC>/devcontrol/subcmd + payload); eg. mysolar/devcontrol/1/0 --> turn on inverter 1; eg. mysolar/devcontrol/1/1 --> turn off; mysolar/devcontrol/0/11 + payload "300" --> set power limit for inverter 1 to 300 W (set power is now remanent during inverter power cycle and remanent during power cycle of ahoy and power limit is set on each reboot/start up THX: @klahus1)
- Set power limit in setup page; Save --> writes to eeprom --> reboot --> after reboot set power limit acc. to eeprom
- Set power limit to zero --> inverter will not stop working (Reactive Power <> 0 VAr) but active power will be zero
- During change of power limit eg. 200 W --> 500 W, the Powerfactor is not controled
- Case "set to unlimited power": NOT working by setting it to large numbers or -1 or similar. You have to set it acc. to the specific device eg. Mi-1500 --> 1500. There is an error handling because the response from inverter differs in case the new power limit is NOT accepted. See logs.

Open:

- prototype for a Web Interface "/devcontrol" created. NO content / function yet.

Suggestion @maintainers:
- create a "dev" branch and merge / accept against this branch. Collect feedback in issues. After the community build/tested then merge against main (= release)
--> "_aschiffler wants to merge 8 commits into grindylow:development_control_"