### PR TITLE
Das subscribe in der Reconnect Procedure sollte doch nur nach einem conect ausgeführt werden und nicht bei jedem Duchlauf

### DIFF
--- a/tools/esp8266/app.cpp
+++ b/tools/esp8266/app.cpp
@@ -165,9 +165,11 @@ void app::setup(uint32_t timeout) {
         mMqtt.setup(mqttAddr, mqttTopic, mqttUser, mqttPwd, mqttDevName, mqttPort);
         mMqtt.mClient->setCallback(std::bind(&app::cbMqtt, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
         mMqttTicker = 0;
+
+#ifdef __MQTT_TEST__
         // für mqtt test
         mMqttTicker = mMqttInterval -10;
-
+#endif
         mSerialTicker = 0;
 
         if(mqttAddr[0] > 0) {
@@ -365,12 +367,17 @@ void app::loop(void) {
                 }
             }
             snprintf(val, 10, "%ld", millis()/1000);
-            // sendMqttDiscoveryConfig();
+            
+#ifndef __MQTT_NO_DISCOVERCONFIG__
+            // MQTTDiscoveryConfig nur wenn nicht abgeschaltet.
+            sendMqttDiscoveryConfig();
+#endif            
             mMqtt.sendMsg("uptime", val);
 
+#ifdef __MQTT_TEST__
             // für einfacheren Test mit MQTT, den MQTT abschnitt in 10 Sekunden wieder ausführen
             mMqttTicker = mMqttInterval -10;
-
+#endif
         }
 
         if(mSerialValues) {
@@ -495,7 +502,9 @@ bool app::buildPayload(uint8_t id) {
 //-----------------------------------------------------------------------------
 void app::processPayload(bool retransmit) {
 
+#ifdef __MQTT_AFTER_RX__
     boolean doMQTT = false;
+#endif
 
     DPRINTLN(DBG_VERBOSE, F("app::processPayload"));
     for(uint8_t id = 0; id < mSys->getNumInverters(); id++) {
@@ -553,23 +562,27 @@ void app::processPayload(bool retransmit) {
                         yield();
                     }
                     iv->doCalculations();
+
+#ifdef __MQTT_AFTER_RX__
                     doMQTT = true;
-                    
+#endif
+
                 }
             }
             yield();
         }
     }
 
-//  ist MQTT aktiviert und es wurden Daten vom einem oder mehreren WR aufbereitet ( doMQTT = true) 
-//  dann die den mMqttTicker auf mMqttIntervall -2 setzen, also  
-//  MQTT aussenden in 2 sek aktivieren 
-//  dies sollte noch über einen Schalter im Setup aktivier / deaktivierbar gemacht werden
+#ifdef __MQTT_AFTER_RX__
+    //  ist MQTT aktiviert und es wurden Daten vom einem oder mehreren WR aufbereitet ( doMQTT = true) 
+    //  dann die den mMqttTicker auf mMqttIntervall -2 setzen, also  
+    //  MQTT aussenden in 2 sek aktivieren 
+    //  dies sollte noch über einen Schalter im Setup aktivier / deaktivierbar gemacht werden
     if( (mMqttInterval != 0xffff) && doMQTT ) {
         ++mMqttTicker = mMqttInterval -2;
         DPRINT(DBG_DEBUG, F("MQTTticker auf Intervall -2 sec ")) ;
     }
-
+#endif
 }
 
 

--- a/tools/esp8266/app.h
+++ b/tools/esp8266/app.h
@@ -17,6 +17,12 @@
 #include "hmSystem.h"
 #include "mqtt.h"
 
+//  hier läst sich das Verhalten der app in Bezug auf MQTT
+//  durch PER-Conpiler defines  anpassen
+//
+// #define __MQTT_TEST__                   // MQTT Interval wird auf 10 Sekunden verkürzt ( nur für testzwecke )
+#define __MQTT_AFTER_RX__               // versendet die MQTT Daten sobald die WR daten Aufbereitet wurden  ( gehört eigentlich ins Setup )
+// #define __MQTT_NO_DISCOVERCONFIG__      // das versenden der MQTTDiscoveryConfig abschalten  ( gehört eigentlich ins Setup )
 
 typedef CircularBuffer<packet_t, PACKET_BUFFER_SIZE> BufferType;
 typedef HmRadio<RF24_CE_PIN, RF24_CS_PIN, RF24_IRQ_PIN, BufferType> RadioType;

--- a/tools/esp8266/defines.h
+++ b/tools/esp8266/defines.h
@@ -21,7 +21,7 @@
 //-------------------------------------
 #define VERSION_MAJOR       0
 #define VERSION_MINOR       5
-#define VERSION_PATCH       5
+#define VERSION_PATCH       6
 
 
 //-------------------------------------

--- a/tools/esp8266/hmRadio.h
+++ b/tools/esp8266/hmRadio.h
@@ -172,16 +172,17 @@ class HmRadio {
                 // 4 bytes control data
                 // Power Limit fix point 10 eg. 30 W --> 0d300 = 0x012c
                 // -1 = 0xffff --> no limit
-                if (data[0] == 0xffff){
-                    data[0] &= 0xffff; // ToDo: unlimit value is needed and is inverter specific! --> get it via RF from inverter or via user interface
+                uint16_t powerLimit = data[0];
+                uint16_t powerLimitSetting = data[1];
+                if (powerLimit == 0xffff){
+                    powerLimit &= 0xffff; // ToDo: unlimit value is needed and is inverter specific! --> get it via RF from inverter or via user interface
                 } else {
-                    data[0] *= 10; // will overwrite the data bc it is a pointer
+                    powerLimit *= 10; // will overwrite the data bc it is a pointer
                 }
-                mTxBuf[10 + (++cnt)] = (data[0] >> 8) & 0xff; // power limit
-                mTxBuf[10 + (++cnt)] = (data[0]     ) & 0xff; // power limit
-                mTxBuf[10 + (++cnt)] = (data[1] >> 8) & 0xff; // setting for persistens handling
-                mTxBuf[10 + (++cnt)] = (data[1]     ) & 0xff; // setting for persistens handling
-                data[0] /= 10; // UGLY!
+                mTxBuf[10 + (++cnt)] = (powerLimit >> 8) & 0xff; // power limit
+                mTxBuf[10 + (++cnt)] = (powerLimit     ) & 0xff; // power limit
+                mTxBuf[10 + (++cnt)] = (powerLimitSetting >> 8) & 0xff; // setting for persistens handling
+                mTxBuf[10 + (++cnt)] = (powerLimitSetting     ) & 0xff; // setting for persistens handling
             }
             // crc control data
             uint16_t crc = crc16(&mTxBuf[10], cnt+1);

--- a/tools/esp8266/mqtt.h
+++ b/tools/esp8266/mqtt.h
@@ -121,12 +121,13 @@ class mqtt {
                     else
                         mClient->connect(mDevName);
                 }
+                // ein Subscribe ist nur nach einem connect notwendig
+                char topic[MQTT_TOPIC_LEN + 13 ]; // "/devcontrol/#" --> + 6 byte
+                // ToDo: "/devcontrol/#" is hardcoded 
+                snprintf(topic, MQTT_TOPIC_LEN + 13, "%s/devcontrol/#", mTopic); 
+                DPRINTLN(DBG_INFO, F("subscribe to ") + String(topic));
+                mClient->subscribe(topic); // subscribe to mTopic + "/devcontrol/#"
             }
-            char topic[MQTT_TOPIC_LEN + 13 ]; // "/devcontrol/#" --> + 6 byte
-            // ToDo: "/devcontrol/#" is hardcoded 
-            snprintf(topic, MQTT_TOPIC_LEN + 13, "%s/devcontrol/#", mTopic); 
-            DPRINTLN(DBG_INFO, F("subscribe to ") + String(topic));
-            mClient->subscribe(topic); // subscribe to mTopic + "/devcontrol/#"
         }
 
         WiFiClient mEspClient;


### PR DESCRIPTION
Ich bin der Meineung, das das setzen des subscrieb in der reconnect procedure an der falschen Stelle eingebaut ist.
Es wird bei jedem check der Verbindung ein subscriebe ausgeführt.  

Sollte das subscriebe nicht nur nach einem connect ausgeführt werden ?

Ich habe meine Anpassungen für das versenden der MQTT Daten nach der Verarbeitung der WR daten wieder eingebeut.
Ich habe es diesmal aber so  gemacht, das es sich mit defines in der app.h aktivieren lässt. 
Sind die Defines nicht gesetzt, bleibt es bei bisherigem Ablauf.

Ausserdem gibt es noch zwei weitere Defines :
  einer zum Abschalten des sendMqttDiscoveryConfig  ( nicht alle benötigen das Discovery ; spart viel CPU Zeit / Funkbelegung )
  einer zum Einschalten eines kurzen MQTT Intervals von 10 Sekunden ( für Testzwecke )

