### PR TITLE
d1_mini and nodemcu env merged, debug option added

### DIFF
--- a/tools/esp8266/platformio.ini
+++ b/tools/esp8266/platformio.ini
@@ -11,10 +11,10 @@
 [platformio]
 src_dir = .
 
-[env:d1_mini]
+[env]
 platform = espressif8266
 framework = arduino
-board = d1_mini
+board = esp12e
 board_build.f_cpu = 80000000L
 
 ; ;;;;; Possible Debug options ;;;;;;
@@ -27,10 +27,6 @@ board_build.f_cpu = 80000000L
 	;-DDEBUG_ESP_OOM 
 
 monitor_speed = 115200
-monitor_filters = 
-	;default   ; Remove typical terminal control codes from input
-	time      ; Add timestamp with milliseconds for each new line
-    ;log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
 
 extra_scripts =
     pre:scripts/auto_firmware_version.py
@@ -49,41 +45,19 @@ lib_deps =
     ;esp8266/SPI@1.0
     ;esp8266/Ticker@^1.0
 
-[env:node_mcu_v2]
-platform = espressif8266
-framework = arduino
-board = nodemcuv2
-board_build.f_cpu = 80000000L
-
-; ;;;;; Possible Debug options ;;;;;;
-; https://docs.platformio.org/en/latest/platforms/espressif8266.html#debug-level
-;build_flags = -DDEBUG_ESP_PORT=Serial
-    ;-DDEBUG_ESP_CORE 
-	;-DDEBUG_ESP_WIFI 
-	;-DDEBUG_ESP_HTTP_CLIENT 
-	;-DDEBUG_ESP_HTTP_SERVER 
-	;-DDEBUG_ESP_OOM 
-
-monitor_speed = 115200
+[env:esp8266-release]
+build_flags = -D RELEASE
 monitor_filters = 
 	;default   ; Remove typical terminal control codes from input
-	time       ; Add timestamp with milliseconds for each new line
+	time      ; Add timestamp with milliseconds for each new line
     ;log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
-upload_port = /dev/ttyUSB0
 
-extra_scripts =
-    pre:scripts/auto_firmware_version.py
-    pre:html/convert.py html/
 
-lib_deps = 
-	nrf24/RF24@1.4.5
-	paulstoffregen/Time@^1.6.1
-	knolleary/PubSubClient@^2.8
-	bblanchon/ArduinoJson@^6.19.4
-    ;esp8266/DNSServer@1.1.0
-    ;esp8266/EEPROM@^1.0
-    ;esp8266/ESP8266HTTPUpdateServer@^1.0
-    ;esp8266/ESP8266WebServer@^1.0
-    ;esp8266/ESP8266WiFi@^1.0
-    ;esp8266/SPI@1.0
-    ;esp8266/Ticker@^1.0
+[env:esp8266-debug]
+build_flags = -DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_OOM -DDEBUG_ESP_PORT=Serial
+build_type = debug
+
+monitor_filters = 
+	;default   ; Remove typical terminal control codes from input
+	time      ; Add timestamp with milliseconds for each new line
+    log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory


### PR DESCRIPTION
Unnütze Unterscheidung zwischen d1_mini und node_mcu_v2 environments entfernt. Die beiden sind 100% identisch, abgesehen davon, dass bei node_mcu_v2 der upload_port hard-coded war. Habe es jetzt aufgeteilt in eine "release" environment ohne Logging und eine optionale "debug" environment mit gesetzten debug flags und log2file.