### PR TITLE
Added options for TLS usage for MQTT client and insecure certificate …

### DIFF
--- a/tools/rpi/ahoy.yml.example
+++ b/tools/rpi/ahoy.yml.example
@@ -16,6 +16,8 @@ ahoy:
     port: 1883
     user: 'username'
     password: 'password'
+    useTLS: False
+    insecureTLS: False #set True for e.g. self signed certificates. 
 
   # Influx2 output
   influxdb:

--- a/tools/rpi/hoymiles/__main__.py
+++ b/tools/rpi/hoymiles/__main__.py
@@ -226,6 +226,11 @@ if __name__ == '__main__':
     mqtt_config = ahoy_config.get('mqtt', [])
     if not mqtt_config.get('disabled', False):
         mqtt_client = paho.mqtt.client.Client()
+        
+        if mqtt_config.get('useTLS',False):
+            mqtt_client.tls_set()
+            mqtt_client.tls_insecure_set(mqtt_config.get('insecureTLS',False))
+
         mqtt_client.username_pw_set(mqtt_config.get('user', None), mqtt_config.get('password', None))
         mqtt_client.connect(mqtt_config.get('host', '127.0.0.1'), mqtt_config.get('port', 1883))
         mqtt_client.loop_start()


### PR DESCRIPTION
Added two options in example.ahoi.yaml to enable MQTT client to use TLS.
Defaults to False. Also added an option to enable insecure TLS for e.g. self signed certificates. 

Tested with TLS: true, insecureTLS: false for letsencrypt secured mosquitto server.

Thanks for this awesome project! Got it to run with my hm-600 in just on evening.