### PR TITLE
Add MF & MDL for MQTT (HASSIO-Discov.) - man. Ver.

### DIFF
--- a/tools/esp8266/app.cpp
+++ b/tools/esp8266/app.cpp
@@ -1153,6 +1153,8 @@ void app::sendMqttDiscoveryConfig(void) {
                 deviceDoc["name"] = iv->name;
                 deviceDoc["ids"] = String(iv->serial.u64, HEX);
                 deviceDoc["cu"] = F("http://") + String(WiFi.localIP().toString());
+                deviceDoc["mf"] = "Hoymiles";
+                deviceDoc["mdl"] = iv->name;
                 JsonObject deviceObj = deviceDoc.as<JsonObject>();
                 DynamicJsonDocument doc(384);
 


### PR DESCRIPTION
kleine Anpassung im Bereich MQTT Autodiscover für HomeAssistant um die Werte Hersteller und Modell.
Hersteller ist static auf "Hoymiles" hinterlegt.
Das Modell wird aus dem Namen des WR im Setup gezogen.
Könnte als Zwischenlösung dienen, bis diese Daten evtl. aus dem WR direkt gezogen werden können, dann müsste man nur entsprechende Variablen hinterlegen.
