### PR TITLE
ESP32 adjustments, compiles but doesn't run yet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tools/esp8266/binaries
 tools/esp8266/.vscode/extensions.json
 .DS_Store
 .vscode
+tools/esp8266/platformio-device-monitor-*.log

--- a/tools/esp8266/CircularBuffer.h
+++ b/tools/esp8266/CircularBuffer.h
@@ -24,6 +24,9 @@
 #ifdef ESP8266
 #define DISABLE_IRQ noInterrupts()
 #define RESTORE_IRQ interrupts()
+#elif defined(ESP32)
+#define DISABLE_IRQ noInterrupts()
+#define RESTORE_IRQ interrupts()
 #else
 #define DISABLE_IRQ       \
     uint8_t sreg = SREG;    \

--- a/tools/esp8266/ahoywifi.cpp
+++ b/tools/esp8266/ahoywifi.cpp
@@ -3,7 +3,11 @@
 // Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
 //-----------------------------------------------------------------------------
 
-#include "wifi.h"
+#if defined(ESP32) && defined(F)
+  #undef F
+  #define F(sl) (sl)
+#endif
+#include "ahoywifi.h"
 
 
 // NTP CONFIG
@@ -12,7 +16,7 @@
 
 
 //-----------------------------------------------------------------------------
-wifi::wifi(app *main, sysConfig_t *sysCfg, config_t *config) {
+ahoywifi::ahoywifi(app *main, sysConfig_t *sysCfg, config_t *config) {
     mMain    = main;
     mSysCfg  = sysCfg;
     mConfig  = config;
@@ -29,7 +33,7 @@ wifi::wifi(app *main, sysConfig_t *sysCfg, config_t *config) {
 
 
 //-----------------------------------------------------------------------------
-void wifi::setup(uint32_t timeout, bool settingValid) {
+void ahoywifi::setup(uint32_t timeout, bool settingValid) {
     mWifiStationTimeout = timeout;
     #ifndef AP_ONLY
         if(false == mApActive)
@@ -58,7 +62,7 @@ void wifi::setup(uint32_t timeout, bool settingValid) {
 
 
 //-----------------------------------------------------------------------------
-bool wifi::loop(void) {
+bool ahoywifi::loop(void) {
     if(mApActive) {
         mDns->processNextRequest();
 #ifndef AP_ONLY
@@ -98,7 +102,7 @@ bool wifi::loop(void) {
 
 
 //-----------------------------------------------------------------------------
-void wifi::setupAp(const char *ssid, const char *pwd) {
+void ahoywifi::setupAp(const char *ssid, const char *pwd) {
     DPRINTLN(DBG_VERBOSE, F("app::setupAp"));
     IPAddress apIp(192, 168, 1, 1);
 
@@ -118,7 +122,7 @@ void wifi::setupAp(const char *ssid, const char *pwd) {
 
 
 //-----------------------------------------------------------------------------
-bool wifi::setupStation(uint32_t timeout) {
+bool ahoywifi::setupStation(uint32_t timeout) {
     DPRINTLN(DBG_VERBOSE, F("app::setupStation"));
     int32_t cnt;
     bool startAp = false;
@@ -166,12 +170,12 @@ bool wifi::setupStation(uint32_t timeout) {
 
 
 //-----------------------------------------------------------------------------
-bool wifi::getApActive(void) {
+bool ahoywifi::getApActive(void) {
     return mApActive;
 }
 
 //-----------------------------------------------------------------------------
-time_t wifi::getNtpTime(void) {
+time_t ahoywifi::getNtpTime(void) {
     //DPRINTLN(DBG_VERBOSE, F("wifi::getNtpTime"));
     time_t date = 0;
     IPAddress timeServer;
@@ -209,7 +213,7 @@ time_t wifi::getNtpTime(void) {
 
 
 //-----------------------------------------------------------------------------
-void wifi::sendNTPpacket(IPAddress& address) {
+void ahoywifi::sendNTPpacket(IPAddress& address) {
     //DPRINTLN(DBG_VERBOSE, F("wifi::sendNTPpacket"));
     uint8_t buf[NTP_PACKET_SIZE] = {0};
 
@@ -232,7 +236,7 @@ void wifi::sendNTPpacket(IPAddress& address) {
 //-----------------------------------------------------------------------------
 // calculates the daylight saving time for middle Europe. Input: Unixtime in UTC
 // from: https://forum.arduino.cc/index.php?topic=172044.msg1278536#msg1278536
-time_t wifi::offsetDayLightSaving (uint32_t local_t) {
+time_t ahoywifi::offsetDayLightSaving (uint32_t local_t) {
     //DPRINTLN(DBG_VERBOSE, F("wifi::offsetDayLightSaving"));
     int m = month (local_t);
     if(m < 3 || m > 10) return 0; // no DSL in Jan, Feb, Nov, Dez

--- a/tools/esp8266/ahoywifi.h
+++ b/tools/esp8266/ahoywifi.h
@@ -3,12 +3,17 @@
 // Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
 //-----------------------------------------------------------------------------
 
-#ifndef __WIFI_H__
-#define __WIFI_H__
+#ifndef __AHOYWIFI_H__
+#define __AHOYWIFI_H__
 
 #include "dbg.h"
-#include <ESP8266WiFi.h>
-#include <ESP8266WebServer.h>
+#ifdef ESP8266
+    #include <ESP8266WebServer.h>
+    #include <ESP8266WiFi.h>
+#elif defined(ESP32)
+    #include <WebServer.h>
+    #include <WiFi.h>
+#endif
 
 // NTP
 #include <WiFiUdp.h>
@@ -21,10 +26,10 @@
 
 class app;
 
-class wifi {
+class ahoywifi {
     public:
-        wifi(app *main, sysConfig_t *sysCfg, config_t *config);
-        ~wifi() {}
+        ahoywifi(app *main, sysConfig_t *sysCfg, config_t *config);
+        ~ahoywifi() {}
 
         void setup(uint32_t timeout, bool settingValid);
         bool loop(void);
@@ -32,7 +37,7 @@ class wifi {
         bool setupStation(uint32_t timeout);
         bool getApActive(void);
         time_t getNtpTime(void);
-
+        
     private:
         void sendNTPpacket(IPAddress& address);
         time_t offsetDayLightSaving (uint32_t local_t);
@@ -52,4 +57,4 @@ class wifi {
         bool wifiWasEstablished;
 };
 
-#endif /*__WIFI_H__*/
+#endif /*__AHOYWIFI_H__*/

--- a/tools/esp8266/app.cpp
+++ b/tools/esp8266/app.cpp
@@ -22,7 +22,7 @@ app::app() {
 DPRINTLN(DBG_VERBOSE, F("app::web"));
     mWebInst = new web(this, &mSysConfig, &mConfig, mVersion);
     DPRINTLN(DBG_VERBOSE, F("app::setup"));
-    //mWebInst->setup();
+    mWebInst->setup();
 DPRINTLN(DBG_VERBOSE, F("app::reset"));
     resetSystem();
     DPRINTLN(DBG_VERBOSE, F("app::config"));

--- a/tools/esp8266/app.cpp
+++ b/tools/esp8266/app.cpp
@@ -17,16 +17,10 @@ app::app() {
     Serial.begin(115200);
     DPRINTLN(DBG_VERBOSE, F("app::app"));
     mEep = new eep();
-    DPRINTLN(DBG_VERBOSE, F("app::wifi"));
     mWifi = new ahoywifi(this, &mSysConfig, &mConfig);
-DPRINTLN(DBG_VERBOSE, F("app::web"));
-    mWebInst = new web(this, &mSysConfig, &mConfig, mVersion);
-    DPRINTLN(DBG_VERBOSE, F("app::setup"));
-    mWebInst->setup();
-DPRINTLN(DBG_VERBOSE, F("app::reset"));
+
     resetSystem();
-    DPRINTLN(DBG_VERBOSE, F("app::config"));
-    loadDefaultConfig();
+   loadDefaultConfig();
 
     mSys = new HmSystemType();
 }
@@ -34,8 +28,7 @@ DPRINTLN(DBG_VERBOSE, F("app::reset"));
 
 //-----------------------------------------------------------------------------
 void app::setup(uint32_t timeout) {
-    DPRINTLN(DBG_VERBOSE, F("app::setup"));
-
+ 
     mWifiSettingsValid = checkEEpCrc(ADDR_START, ADDR_WIFI_CRC, ADDR_WIFI_CRC);
     mSettingsValid = checkEEpCrc(ADDR_START_SETTINGS, ((ADDR_NEXT)-(ADDR_START_SETTINGS)), ADDR_SETTINGS_CRC);
     loadEEpconfig();
@@ -46,6 +39,9 @@ void app::setup(uint32_t timeout) {
         setupMqtt();
     #endif
     mSys->setup(&mConfig);
+
+    mWebInst = new web(this, &mSysConfig, &mConfig, mVersion);
+    mWebInst->setup();
 }
 
 //-----------------------------------------------------------------------------

--- a/tools/esp8266/app.cpp
+++ b/tools/esp8266/app.cpp
@@ -3,22 +3,29 @@
 // Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
 //-----------------------------------------------------------------------------
 
+#if defined(ESP32) && defined(F)
+  #undef F
+  #define F(sl) (sl)
+#endif
+
 #include "app.h"
 #include <ArduinoJson.h>
 
 
 //-----------------------------------------------------------------------------
 app::app() {
+    Serial.begin(115200);
     DPRINTLN(DBG_VERBOSE, F("app::app"));
     mEep = new eep();
-    Serial.begin(115200);
-
-    mWifi = new wifi(this, &mSysConfig, &mConfig);
-
+    DPRINTLN(DBG_VERBOSE, F("app::wifi"));
+    mWifi = new ahoywifi(this, &mSysConfig, &mConfig);
+DPRINTLN(DBG_VERBOSE, F("app::web"));
     mWebInst = new web(this, &mSysConfig, &mConfig, mVersion);
-    mWebInst->setup();
-
+    DPRINTLN(DBG_VERBOSE, F("app::setup"));
+    //mWebInst->setup();
+DPRINTLN(DBG_VERBOSE, F("app::reset"));
     resetSystem();
+    DPRINTLN(DBG_VERBOSE, F("app::config"));
     loadDefaultConfig();
 
     mSys = new HmSystemType();
@@ -433,7 +440,7 @@ void app::cbMqtt(char* topic, byte* payload, unsigned int length) {
     const char *token = strtok(topic, "/");
     while (token != NULL)
     {   
-        if (std::strcmp(token,"devcontrol")==0){
+        if (strcmp(token,"devcontrol")==0){
             token = strtok(NULL, "/");
             uint8_t iv_id = std::stoi(token);
             if (iv_id >= 0  && iv_id <= MAX_NUM_INVERTERS){

--- a/tools/esp8266/app.h
+++ b/tools/esp8266/app.h
@@ -21,7 +21,7 @@
 #include "CircularBuffer.h"
 #include "hmSystem.h"
 #include "mqtt.h"
-#include "wifi.h"
+#include "ahoywifi.h"
 #include "web.h"
 
 //  hier läst sich das Verhalten der app in Bezug auf MQTT
@@ -56,7 +56,7 @@ typedef struct {
 } invPayload_t;
 
 
-class wifi;
+class ahoywifi;
 class web;
 
 class app {
@@ -200,10 +200,19 @@ class app {
 
         void stats(void) {
             DPRINTLN(DBG_VERBOSE, F("main.h:stats"));
-            uint32_t free;
-            uint16_t max;
-            uint8_t frag;
-            ESP.getHeapStats(&free, &max, &frag);
+            #ifdef ESP8266
+                uint32_t free;
+                uint16_t max;
+                uint8_t frag;
+                ESP.getHeapStats(&free, &max, &frag);
+            #elif defined(ESP32)
+                uint32_t free;
+                uint32_t max;
+                uint8_t frag;
+                free = ESP.getFreeHeap();
+                max = ESP.getMaxAllocHeap();
+                frag = 0;
+            #endif
             DPRINT(DBG_VERBOSE, F("free: ") + String(free));
             DPRINT(DBG_VERBOSE, F(" - max: ") + String(max) + "%");
             DPRINTLN(DBG_VERBOSE, F(" - frag: ") + String(frag));
@@ -224,7 +233,7 @@ class app {
 
         bool mShowRebootRequest;
 
-        wifi *mWifi;
+        ahoywifi *mWifi;
         web *mWebInst;
         sysConfig_t mSysConfig;
         config_t mConfig;

--- a/tools/esp8266/eep.h
+++ b/tools/esp8266/eep.h
@@ -18,7 +18,7 @@ class eep {
             
             #ifdef ESP32
                 if(!EEPROM.begin(4096)) {
-                    Serial.println(nvs_flash_init());
+                    nvs_flash_init();
                     EEPROM.begin(4096);
                 }
             #else

--- a/tools/esp8266/eep.h
+++ b/tools/esp8266/eep.h
@@ -8,11 +8,23 @@
 
 #include "Arduino.h"
 #include <EEPROM.h>
+#ifdef ESP32
+    #include <nvs_flash.h>
+#endif
 
 class eep {
     public:
         eep() {
-            EEPROM.begin(4096);
+            
+            #ifdef ESP32
+                if(!EEPROM.begin(4096)) {
+                    Serial.println(nvs_flash_init());
+                    EEPROM.begin(4096);
+                }
+            #else
+                EEPROM.begin(4096);
+            #endif
+
         }
         ~eep() {
             EEPROM.end();

--- a/tools/esp8266/hmInverter.h
+++ b/tools/esp8266/hmInverter.h
@@ -6,6 +6,11 @@
 #ifndef __HM_INVERTER_H__
 #define __HM_INVERTER_H__
 
+#if defined(ESP32) && defined(F)
+  #undef F
+  #define F(sl) (sl)
+#endif
+
 #include "hmDefines.h"
 
 /**

--- a/tools/esp8266/include/dbg.h
+++ b/tools/esp8266/include/dbg.h
@@ -21,7 +21,7 @@
 
 //-----------------------------------------------------------------------------
 // globally used level
-#define DEBUG_LEVEL DBG_VERBOSE
+#define DEBUG_LEVEL DBG_INFO
 
 #ifdef ARDUINO
   #include "Arduino.h"

--- a/tools/esp8266/include/dbg.h
+++ b/tools/esp8266/include/dbg.h
@@ -5,6 +5,10 @@
 
 #ifndef __DBG_H__
 #define __DBG_H__
+#if defined(ESP32) && defined(F)
+  #undef F
+  #define F(sl) (sl)
+#endif
 
 //-----------------------------------------------------------------------------
 // available levels
@@ -17,7 +21,7 @@
 
 //-----------------------------------------------------------------------------
 // globally used level
-#define DEBUG_LEVEL DBG_INFO
+#define DEBUG_LEVEL DBG_VERBOSE
 
 #ifdef ARDUINO
   #include "Arduino.h"

--- a/tools/esp8266/mqtt.h
+++ b/tools/esp8266/mqtt.h
@@ -6,7 +6,16 @@
 #ifndef __MQTT_H__
 #define __MQTT_H__
 
-#include <ESP8266WiFi.h>
+#ifdef ESP8266
+    #include <ESP8266WiFi.h>
+#elif defined(ESP32)
+    #include <WiFi.h>
+#endif
+
+#if defined(ESP32) && defined(F)
+  #undef F
+  #define F(sl) (sl)
+#endif
 #include <PubSubClient.h>
 #include "defines.h"
 
@@ -70,7 +79,9 @@ class mqtt {
         void reconnect(void) {
             DPRINTLN(DBG_DEBUG, F("mqtt.h:reconnect"));
             DPRINTLN(DBG_DEBUG, F("MQTT mClient->_state ") + String(mClient->state()) );
-            DPRINTLN(DBG_DEBUG, F("WIFI mEspClient.status ") + String(mEspClient.status()) );
+            #ifdef ESP8266
+                DPRINTLN(DBG_DEBUG, F("WIFI mEspClient.status ") + String(mEspClient.status()) );
+            #endif
             if(!mClient->connected()) {
                 if(strlen(mDevName) > 0) {
                     // der Server und der Port müssen neu gesetzt werden, 

--- a/tools/esp8266/platformio.ini
+++ b/tools/esp8266/platformio.ini
@@ -12,10 +12,7 @@
 src_dir = .
 
 [env]
-platform = espressif8266
 framework = arduino
-board = esp12e
-board_build.f_cpu = 80000000L
 
 ; ;;;;; Possible Debug options ;;;;;;
 ; https://docs.platformio.org/en/latest/platforms/espressif8266.html#debug-level
@@ -46,17 +43,40 @@ lib_deps =
     ;esp8266/Ticker@^1.0
 
 [env:esp8266-release]
+platform = espressif8266
+board = esp12e
+board_build.f_cpu = 80000000L
 build_flags = -D RELEASE
 monitor_filters = 
 	;default   ; Remove typical terminal control codes from input
 	time      ; Add timestamp with milliseconds for each new line
     ;log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
 
-
 [env:esp8266-debug]
+platform = espressif8266
+board = esp12e
+board_build.f_cpu = 80000000L
 build_flags = -DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_OOM -DDEBUG_ESP_PORT=Serial
 build_type = debug
+monitor_filters = 
+	;default   ; Remove typical terminal control codes from input
+	time      ; Add timestamp with milliseconds for each new line
+    log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
 
+[env:esp32-wroom32-release]
+platform = espressif32
+board = lolin_d32
+build_flags = -D RELEASE
+monitor_filters = 
+	;default   ; Remove typical terminal control codes from input
+	time      ; Add timestamp with milliseconds for each new line
+    ;log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
+
+[env:esp32-wroom32-debug]
+platform = espressif32
+board = lolin_d32
+build_flags = -DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_OOM -DDEBUG_ESP_PORT=Serial
+build_type = debug
 monitor_filters = 
 	;default   ; Remove typical terminal control codes from input
 	time      ; Add timestamp with milliseconds for each new line

--- a/tools/esp8266/scripts/getVersion.py
+++ b/tools/esp8266/scripts/getVersion.py
@@ -28,4 +28,14 @@ def readVersion(path, infile):
     dst = path + ".pio/build/out/" + versionout
     os.rename(src, dst)
 
+    versionout = version[:-1] + "_esp32_release.bin"
+    src = path + ".pio/build/esp32-wroom32-release/firmware.bin"
+    dst = path + ".pio/build/out/" + versionout
+    os.rename(src, dst)
+
+    versionout = version[:-1] + "_esp32_debug.bin"
+    src = path + ".pio/build/esp32-wroom32-debug/firmware.bin"
+    dst = path + ".pio/build/out/" + versionout
+    os.rename(src, dst)
+    
 readVersion("../", "defines.h")

--- a/tools/esp8266/web.h
+++ b/tools/esp8266/web.h
@@ -7,8 +7,13 @@
 #define __WEB_H__
 
 #include "dbg.h"
-#include <ESP8266WebServer.h>
-#include <ESP8266HTTPUpdateServer.h>
+#ifdef ESP8266
+    #include <ESP8266WebServer.h>
+    #include <ESP8266HTTPUpdateServer.h>
+#elif defined(ESP32)
+    #include <WebServer.h>
+    #include <HTTPUpdateServer.h>
+#endif
 
 #include "app.h"
 
@@ -40,8 +45,13 @@ class web {
         void showWebApi(void);
 
     private:
-        ESP8266WebServer *mWeb;
-        ESP8266HTTPUpdateServer *mUpdater;
+        #ifdef ESP8266
+            ESP8266WebServer *mWeb;
+            ESP8266HTTPUpdateServer *mUpdater;
+        #elif defined(ESP32)
+            WebServer *mWeb;
+            HTTPUpdateServer *mUpdater;
+        #endif
 
         config_t *mConfig;
         sysConfig_t *mSysCfg;


### PR DESCRIPTION
Verschiedene Anpassungen um den Code für ESP32 kompilieren zu können
wifi.cpp und wifi.h mussten umbenannt werden da der Name zu Konfilkten mit der ESP32-Version von ESP8266WiFi.h (WiFi.h) führt.
Seit dem letzten Refaktorieren ist der Code auf dem ESP32 nicht mehr lauffähig. Die setup Methode des Webservers führt zum einem Crash, vermutlich weil der WLAN Kram zu der Zeit noch nicht initialisiert ist.