### PR TITLE
MQTT resubscribe only when reconnected successfully, don't call reconnect() when client is still connected (Issue #176)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tools/esp8266/binaries
 tools/esp8266/.vscode/extensions.json
 .DS_Store
 .vscode
+tools/esp8266/platformio-device-monitor-*.log


### PR DESCRIPTION
Der Titel sagt eigentlich schon alles. Subscribe wird jetzt nur noch ausgeführt wenn vorher eine Verbindung zu MQTT neu hergestellt wurde, und reconnect wird nicht mehr unnötig aufgerufen.