### PR TITLE
Delete checkserial() in the input field

### DIFF
--- a/tools/esp8266/web.cpp
+++ b/tools/esp8266/web.cpp
@@ -185,7 +185,7 @@ void web::showSetup(void) {
         inv += F("<input type=\"text\" class=\"text\" name=\"inv") + String(i) + F("Addr\" value=\"");
         if(NULL != iv)
             inv += String(iv->serial.u64, HEX);
-        inv += F("\"/ maxlength=\"12\" onkeyup=\"checkSerial()\">");
+        inv += F("\"/ maxlength=\"12\">");
 
         inv += F("<label for=\"inv") + String(i) + F("Name\">Name*</label>");
         inv += F("<input type=\"text\" class=\"text\" name=\"inv") + String(i) + F("Name\" value=\"");


### PR DESCRIPTION
Webbrowser error when the site 'setup' is called. 
JS function not exist.

https://github.com/grindylow/ahoy/issues/184 (first row)

**Please check it bevor make a pull!**