### PR TITLE
MQTT reconnect delay, fixed ESP32 build

### DIFF
--- a/tools/esp8266/defines.h
+++ b/tools/esp8266/defines.h
@@ -104,6 +104,7 @@ typedef enum { // ToDo: to be verified by field tests
 #define MQTT_PORT_LEN           2 // uint16_t
 #define MQTT_DISCOVERY_PREFIX   "homeassistant"
 #define MQTT_MAX_PACKET_SIZE    384
+#define MQTT_RECONNECT_DELAY    5000
 
 #define SER_ENABLE_LEN          1 // uint8_t
 #define SER_DEBUG_LEN           1 // uint8_t

--- a/tools/esp8266/mqtt.h
+++ b/tools/esp8266/mqtt.h
@@ -85,7 +85,8 @@ class mqtt {
             #endif
 
             boolean resub = false;
-            if(!mClient->connected()) {
+            if(!mClient->connected() && (millis() - lastReconnect) > MQTT_RECONNECT_DELAY ) {
+                lastReconnect = millis();
                 if(strlen(mDevName) > 0) {
                     // der Server und der Port müssen neu gesetzt werden, 
                     // da ein MQTT_CONNECTION_LOST -3 die Werte zerstört hat.
@@ -95,14 +96,14 @@ class mqtt {
                         resub = mClient->connect(mDevName, mCfg->user, mCfg->pwd);
                     else
                         resub = mClient->connect(mDevName);
-                }
-                // ein Subscribe ist nur nach einem connect notwendig
-                if(resub) {
-                    char topic[MQTT_TOPIC_LEN + 13 ]; // "/devcontrol/#" --> + 6 byte
-                    // ToDo: "/devcontrol/#" is hardcoded 
-                    snprintf(topic, MQTT_TOPIC_LEN + 13, "%s/devcontrol/#", mCfg->topic);
-                    DPRINTLN(DBG_INFO, F("subscribe to ") + String(topic));
-                    mClient->subscribe(topic); // subscribe to mTopic + "/devcontrol/#"
+                                // ein Subscribe ist nur nach einem connect notwendig
+                    if(resub) {
+                        char topic[MQTT_TOPIC_LEN + 13 ]; // "/devcontrol/#" --> + 6 byte
+                        // ToDo: "/devcontrol/#" is hardcoded 
+                        snprintf(topic, MQTT_TOPIC_LEN + 13, "%s/devcontrol/#", mCfg->topic);
+                        DPRINTLN(DBG_INFO, F("subscribe to ") + String(topic));
+                        mClient->subscribe(topic); // subscribe to mTopic + "/devcontrol/#"
+                    }
                 }
             }
         }
@@ -113,6 +114,7 @@ class mqtt {
         bool mAddressSet;
         mqttConfig_t *mCfg;
         char mDevName[DEVNAME_LEN];
+        unsigned long lastReconnect = 0;
 };
 
 #endif /*__MQTT_H_*/

--- a/tools/esp8266/web.cpp
+++ b/tools/esp8266/web.cpp
@@ -453,7 +453,7 @@ void web::showWebApi(void)
             if (cmd == AlarmData){
                 iv->alarmMesIndex = response["payload"];
             }
-            DPRINTLN(DBG_INFO, F("Will make tx-request 0x15 with subcmd ") + String(cmd) + F(" and payload ") + String(response["payload"]));
+            DPRINTLN(DBG_INFO, F("Will make tx-request 0x15 with subcmd ") + String(cmd) + F(" and payload ") + String((uint16_t) response["payload"]));
             // process payload from web request corresponding to the cmd
             iv->enqueCommand<InfoCommand>(cmd);
         }


### PR DESCRIPTION
MQTT versucht jetzt nur noch einen reconnect alle 5 Sekunden, nicht mehr 1000 pro Sekunde wenn der Broker Hostname nicht aufgelöst werden kann (issue #184).
Für den ESP32 Build muss zusätzlich ein (uint16_t) Cast in web.cpp.