### PR TITLE
Add ESP32 Devkitv1 Board to Platformio.ini

### DIFF
--- a/tools/esp8266/platformio.ini
+++ b/tools/esp8266/platformio.ini
@@ -83,3 +83,13 @@ monitor_filters =
 	;default   ; Remove typical terminal control codes from input
 	time      ; Add timestamp with milliseconds for each new line
     log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
+
+[env:esp32doit-devkit-v1]
+platform = espressif32
+board = esp32doit-devkit-v1
+upload_speed = 115200
+build_flags = -D RELEASE
+monitor_filters = 
+	;default   ; Remove typical terminal control codes from input
+	time      ; Add timestamp with milliseconds for each new line
+    ;log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory


### PR DESCRIPTION
ich nutze den ESP32 DeVKITV1 und habe den aufgrund des eigenen Boardeintrags und der angepassten Geschwindigkeit separat aufgenommen.
Lass es aber der Entscheidung im Team ob das so angenommen werden kann, evtl. gibts ja "bessere" Lösungen.