### PR TITLE
RPI: don't throw exception when no valid frame was received

### DIFF
--- a/tools/rpi/hoymiles/__init__.py
+++ b/tools/rpi/hoymiles/__init__.py
@@ -647,7 +647,7 @@ class InverterTransaction:
             self.time_rx = end_frame.time_rx
             tr_len = end_frame.seq - 0x80
         except StopIteration:
-            seq_last = max(frames, key=lambda frame:frame.seq).seq
+            seq_last = max(frames, key=lambda frame:frame.seq).seq if len(frames) else 0
             self.__retransmit_frame(seq_last + 1)
             raise BufferError(f'Missing packet: Last packet {len(self.scratch)}')
 


### PR DESCRIPTION
max(empty_seq) throws an exception, therefore we have to add a check for it.