### PR TITLE
Fix link in README.md to latest esp8266/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ List of approaches
 - [Others, C/C++](tools/nano/NRF24_SendRcv/)
 
 ## Quick Start with ESP8266
-- [Go here ✨](https://github.com/grindylow/ahoy/blob/ahoy_v0.5.16/tools/esp8266/README.md#things-needed)
+- [Go here ✨](https://github.com/grindylow/ahoy/blob/main/tools/esp8266/README.md#things-needed)
 
 
 ## Success Stories


### PR DESCRIPTION
Update link in README.md to the latest /tools/esp8266/README.md#things-needed path.

Rel: #263