### PR TITLE
RPI: properly catch exception when crc8 check failed

### DIFF
--- a/tools/rpi/hoymiles/__init__.py
+++ b/tools/rpi/hoymiles/__init__.py
@@ -203,7 +203,7 @@ class InverterPacketFragment:
 
         # check crc8
         if f_crc8(payload[:-1]) != payload[-1]:
-            raise BufferError('Frame kaputt')
+            raise BufferError('Frame corrupted - crc8 check failed')
 
         self.ch_rx = ch_rx
         self.ch_tx = ch_tx

--- a/tools/rpi/hoymiles/__main__.py
+++ b/tools/rpi/hoymiles/__main__.py
@@ -86,13 +86,13 @@ def poll_inverter(inverter, do_init, retries=4):
                         dst=inverter_ser
                         )))
             response = None
-            while com.rxtx():
-                try:
+            try:
+                while com.rxtx():
                     response = com.get_payload()
                     payload_ttl = 0
-                except Exception as e_all:
-                    print(f'Error while retrieving data: {e_all}')
-                    pass
+            except Exception as e_all:
+                print(f'Error while retrieving data: {e_all}')
+                pass
 
         # Handle the response data if any
         if response:


### PR DESCRIPTION
... otherwise python will exit since the exception is not catched.