### PR TITLE
Update style.css

### DIFF
--- a/tools/esp8266/html/style.css
+++ b/tools/esp8266/html/style.css
@@ -177,7 +177,7 @@ div.ch {
     min-height: 350px;
     background-color: #006ec0;
     display: inline-block;
-    margin: 0 0px 20px 10px;
+    margin: 0 20px 10px 0px;
     overflow: auto;
     padding-bottom: 20px;
 }

--- a/tools/esp8266/html/style.css
+++ b/tools/esp8266/html/style.css
@@ -177,7 +177,7 @@ div.ch {
     min-height: 350px;
     background-color: #006ec0;
     display: inline-block;
-    margin: 0 10px 15px 10px;
+    margin: 0 0px 20px 10px;
     overflow: auto;
     padding-bottom: 20px;
 }


### PR DESCRIPTION
to make two channels better fit side by side on phone(s)

looks like this on my pixel5 right now:
![Screenshot_20221012-231730](https://user-images.githubusercontent.com/3143680/195449804-e998ed0d-bf27-4d73-b966-0ceaa6161afe.jpg)
