### PR TITLE
fix rare crash related to time shift which might cause negative sleep time

### DIFF
--- a/tools/rpi/hoymiles/__main__.py
+++ b/tools/rpi/hoymiles/__main__.py
@@ -322,8 +322,10 @@ if __name__ == '__main__':
 
             print('', end='', flush=True)
 
-            if loop_interval > 0 and (time.time() - t_loop_start) < loop_interval:
-                time.sleep(loop_interval - (time.time() - t_loop_start))
+            time_to_sleep = loop_interval - (time.time() - t_loop_start)
+
+            if loop_interval > 0 and time_to_sleep > 0:
+                time.sleep(time_to_sleep) 
 
     except KeyboardInterrupt:
         sys.exit()


### PR DESCRIPTION
After a couple of days of running fine, the rpi python version eventually crashed:

```
Exception catched: sleep length must be non-negative
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/pi/ahoy/tools/rpi/hoymiles/__main__.py", line 326, in <module>
    time.sleep(loop_interval - (time.time() - t_loop_start))
ValueError: sleep length must be non-negative
```

...seems like there is a rare condition when the sleep time in the main loop can become negative: there were two consecutive calls to time.time() and in between them the time might change e.g. because of ntp synchronization.