### PR TITLE
add support for 1M flash size

### DIFF
--- a/.github/workflows/compile_development.yml
+++ b/.github/workflows/compile_development.yml
@@ -41,7 +41,7 @@ jobs:
       working-directory: tools/esp8266/html
       run: python convert.py
     - name: Run PlatformIO
-      run: pio run -d tools/esp8266 --environment esp8266-release --environment esp32-wroom32-release
+      run: pio run -d tools/esp8266 --environment esp8266-release --environment esp8266-1m-release --environment esp32-wroom32-release
     - name: rename-binary-files
       id: rename-binary-files
       working-directory: tools/esp8266/scripts

--- a/.github/workflows/compile_esp8266.yml
+++ b/.github/workflows/compile_esp8266.yml
@@ -42,7 +42,7 @@ jobs:
       working-directory: tools/esp8266/html
       run: python convert.py
     - name: Run PlatformIO
-      run: pio run -d tools/esp8266 --environment esp8266-release --environment esp32-wroom32-release
+      run: pio run -d tools/esp8266 --environment esp8266-release --environment esp8266-1m-release --environment esp32-wroom32-release
     - name: rename-binary-files
       id: rename-binary-files
       working-directory: tools/esp8266/scripts

--- a/tools/esp8266/platformio.ini
+++ b/tools/esp8266/platformio.ini
@@ -63,6 +63,29 @@ monitor_filters =
 	;default   ; Remove typical terminal control codes from input
 	time      ; Add timestamp with milliseconds for each new line
     log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
+    
+[env:esp8266-1m-release]
+platform = espressif8266
+board = esp8285
+board_build.ldscript = eagle.flash.1m64.ld
+board_build.f_cpu = 80000000L
+build_flags = -D RELEASE
+monitor_filters =
+	;default   ; Remove typical terminal control codes from input
+	time      ; Add timestamp with milliseconds for each new line
+    ;log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
+
+[env:esp8266-1m-debug]
+platform = espressif8266
+board = esp8285
+board_build.ldscript = eagle.flash.1m64.ld
+board_build.f_cpu = 80000000L
+build_flags = -DDEBUG_LEVEL=DBG_DEBUG -DDEBUG_ESP_CORE -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_OOM -DDEBUG_ESP_PORT=Serial
+build_type = debug
+monitor_filters =
+	;default   ; Remove typical terminal control codes from input
+	time      ; Add timestamp with milliseconds for each new line
+    log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
 
 [env:esp32-wroom32-release]
 platform = espressif32

--- a/tools/esp8266/scripts/getVersion.py
+++ b/tools/esp8266/scripts/getVersion.py
@@ -24,6 +24,11 @@ def readVersion(path, infile):
     src = path + ".pio/build/esp8266-release/firmware.bin"
     dst = path + ".pio/build/out/" + versionout
     os.rename(src, dst)
+    
+    versionout = version[:-1] + "_esp8266_1m_" + sha + ".bin"
+    src = path + ".pio/build/esp8266-1m-release/firmware.bin"
+    dst = path + ".pio/build/out/" + versionout
+    os.rename(src, dst)
 
     versionout = version[:-1] + "_esp32_" + sha + ".bin"
     src = path + ".pio/build/esp32-wroom32-release/firmware.bin"


### PR DESCRIPTION
1M Flash size is still enough for ahoy. also OTA update is possible.

RAM:   [====      ]  42.1% (used 34528 bytes from 81920 bytes)
Flash: [====      ]  44.9% (used 430313 bytes from 958448 bytes)

build workflow was successful on github actions: https://github.com/sVnsation/ahoy/actions
firmware archive file now contains 3 files:
ahoy_0.5.25_esp8266
ahoy_0.5.25_esp8266_1m
ahoy_0.5.25_esp32