### PR TITLE
compress firmware bin with gzip for ota

### DIFF
--- a/scripts/getVersion.py
+++ b/scripts/getVersion.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import gzip
 from datetime import date
 
 def genOtaBin(path):
@@ -24,6 +26,11 @@ def genOtaBin(path):
     with open(path + "ota.bin", "wb") as f:
         f.write(bytearray(arr))
 
+# write gzip firmware file
+def gzip_bin(bin_file, gzip_file):
+    with open(bin_file,"rb") as fp:
+        with gzip.open(gzip_file, "wb", compresslevel = 9) as f:
+            shutil.copyfileobj(fp, f)
 
 def readVersion(path, infile):
     f = open(path + infile, "r")
@@ -48,16 +55,19 @@ def readVersion(path, infile):
     src = path + ".pio/build/esp8266-release/firmware.bin"
     dst = path + "firmware/" + versionout
     os.rename(src, dst)
+    gzip_bin(dst, dst + ".gz")
     
     versionout = version[:-1] + "_esp8266_1m_" + sha + ".bin"
     src = path + ".pio/build/esp8285-release/firmware.bin"
     dst = path + "firmware/" + versionout
     os.rename(src, dst)
+    gzip_bin(dst, dst + ".gz")
 
     versionout = version[:-1] + "_esp32_" + sha + ".bin"
     src = path + ".pio/build/esp32-wroom32-release/firmware.bin"
     dst = path + "firmware/" + versionout
     os.rename(src, dst)
+    gzip_bin(dst, dst + ".gz")
 
     # other ESP32 bin files
     src = path + ".pio/build/esp32-wroom32-release/"


### PR DESCRIPTION
Unfortunately, more than 50% is occupied in the version with 1M Flash:
Flash: [===== ] 50.6% (used 484985 bytes from 958448 bytes)
However, OTA is still possible thanks to the gzip compression of the firmware.
This PR also generates gzip compressed .bin.gz files for firmware ota.

The workflow runs successfully and generates .bin.gz files
example: https://github.com/sVnsation/ahoy/actions