### PR TITLE
mqtt avoid trailing zeroes - like web-ui

### DIFF
--- a/src/publisher/pubMqtt.h
+++ b/src/publisher/pubMqtt.h
@@ -378,7 +378,7 @@ class PubMqtt {
                     if(iv->isAvailable(*mUtcTimestamp, rec)) {
                         for (uint8_t i = 0; i < rec->length; i++) {
                             snprintf(topic, 32 + MAX_NAME_LENGTH, "%s/ch%d/%s", iv->config->name, rec->assign[i].ch, fields[rec->assign[i].fieldId]);
-                            snprintf(val, 40, "%.3f", iv->getValue(i, rec));
+                            snprintf(val, sizeof(val), "%g", ah::round3(iv->getValue(i, rec)));
                             publish(topic, val);
 
                             // calculate total values for RealTimeRunData_Debug
@@ -427,7 +427,7 @@ class PubMqtt {
                                 break;
                         }
                         snprintf(topic, 32 + MAX_NAME_LENGTH, "total/%s", fields[fieldId]);
-                        snprintf(val, 40, "%.3f", total[i]);
+                        snprintf(val, sizeof(val), "%g", ah::round3(total[i]));
                         publish(topic, val);
                     }
                 }

--- a/src/utils/helper.cpp
+++ b/src/utils/helper.cpp
@@ -26,4 +26,8 @@ namespace ah {
         else
             snprintf(str, 16, "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
     }
+
+    double round3(double value) {
+        return (int)(value * 1000 + 0.5) / 1000.0;
+    }
 }

--- a/src/utils/helper.h
+++ b/src/utils/helper.h
@@ -14,6 +14,7 @@
 namespace ah {
     void ip2Arr(uint8_t ip[], const char *ipStr);
     void ip2Char(uint8_t ip[], char *str);
+    double round3(double value);
 }
 
 #endif /*__HELPER_H__*/

--- a/src/web/webApi.cpp
+++ b/src/web/webApi.cpp
@@ -448,7 +448,7 @@ void webApi::getLive(JsonObject obj) {
             JsonObject obj2 = invArr.createNestedObject();
             obj2[F("name")]               = String(iv->config->name);
             obj2[F("channels")]           = iv->channels;
-            obj2[F("power_limit_read")]   = round3(iv->actPowerLimit);
+            obj2[F("power_limit_read")]   = ah::round3(iv->actPowerLimit);
             obj2[F("last_alarm")]         = String(iv->lastAlarmMsg);
             obj2[F("ts_last_success")]    = rec->ts;
 
@@ -457,7 +457,7 @@ void webApi::getLive(JsonObject obj) {
             obj2[F("ch_names")][0] = "AC";
             for (uint8_t fld = 0; fld < sizeof(list); fld++) {
                 pos = (iv->getPosByChFld(CH0, list[fld], rec));
-                ch0[fld] = (0xff != pos) ? round3(iv->getValue(pos, rec)) : 0.0;
+                ch0[fld] = (0xff != pos) ? ah::round3(iv->getValue(pos, rec)) : 0.0;
                 obj[F("ch0_fld_units")][fld] = (0xff != pos) ? String(iv->getUnit(pos, rec)) : notAvail;
                 obj[F("ch0_fld_names")][fld] = (0xff != pos) ? String(iv->getFieldName(pos, rec)) : notAvail;
             }
@@ -474,7 +474,7 @@ void webApi::getLive(JsonObject obj) {
                         case 4:  pos = (iv->getPosByChFld(j, FLD_YT, rec));  break;
                         case 5:  pos = (iv->getPosByChFld(j, FLD_IRR, rec)); break;
                     }
-                    cur[k] = (0xff != pos) ? round3(iv->getValue(pos, rec)) : 0.0;
+                    cur[k] = (0xff != pos) ? ah::round3(iv->getValue(pos, rec)) : 0.0;
                     if(1 == j) {
                         obj[F("fld_units")][k] = (0xff != pos) ? String(iv->getUnit(pos, rec)) : notAvail;
                         obj[F("fld_names")][k] = (0xff != pos) ? String(iv->getFieldName(pos, rec)) : notAvail;

--- a/src/web/webApi.h
+++ b/src/web/webApi.h
@@ -59,10 +59,6 @@ class webApi {
         bool setCtrl(JsonObject jsonIn, JsonObject jsonOut);
         bool setSetup(JsonObject jsonIn, JsonObject jsonOut);
 
-        double round3(double value) {
-           return (int)(value * 1000 + 0.5) / 1000.0;
-        }
-
         AsyncWebServer *mSrv;
         app *mApp;
 


### PR DESCRIPTION
The web-ui does not show trailing zeroes for the values.
To also avoid these trailing zeroes send via mqtt, the same round3 function like in the web-ui can be used.

Therefore the round3 function is moved to the helpers and will be used before the mqtt publish.
snprintf formating with %g omits the zeroes.