### PR TITLE
RPI: Fix reading negative temperature - must be treated as signed short, not unsigned short

### DIFF
--- a/tools/rpi/hoymiles/decoders/__init__.py
+++ b/tools/rpi/hoymiles/decoders/__init__.py
@@ -440,7 +440,7 @@ class Hm300Decode0B(StatusResponse):
     @property
     def temperature(self):
         """ Inverter temperature in °C """
-        return self.unpack('>H', 26)[0]/10
+        return self.unpack('>h', 26)[0]/10
 
 class Hm300Decode0C(Hm300Decode0B):
     """ 1121-series mirco-inverters status data """


### PR DESCRIPTION
Maybe also a problem in code for ESP?