### PR TITLE
change AC_CURRENT divider to 100

### DIFF
--- a/tools/rpi/hoymiles/decoders/__init__.py
+++ b/tools/rpi/hoymiles/decoders/__init__.py
@@ -511,7 +511,7 @@ class Hm600Decode0B(StatusResponse):
     @property
     def ac_current_0(self):
         """ Phase 1 ampere """
-        return self.unpack('>H', 34)[0]/10
+        return self.unpack('>H', 34)[0]/100
     @property
     def ac_power_0(self):
         """ Phase 1 watts """


### PR DESCRIPTION
In line 514, ac_current dividor must be 100 not 10
There is a mismatch in AC output: power[Watt] = voltage[Volt] * current[Ampere]