### PR TITLE
RPI: avoid error if mqtt is not defined

### DIFF
--- a/tools/rpi/hoymiles/__main__.py
+++ b/tools/rpi/hoymiles/__main__.py
@@ -345,8 +345,8 @@ if __name__ == '__main__':
     if global_config.verbose:
         hoymiles.HOYMILES_DEBUG_LOGGING=True
 
-    mqtt_config = ahoy_config.get('mqtt', [])
-    if not mqtt_config.get('disabled', False):
+    mqtt_config = ahoy_config.get('mqtt', {})
+    if mqtt_config and not mqtt_config.get('disabled', False):
         mqtt_client = paho.mqtt.client.Client()
         
         if mqtt_config.get('useTLS',False):


### PR DESCRIPTION
If MQTT is not defined in ahoy.yml, ahoy send an AttributeError