### PR TITLE
RPI:using pyRF24 on Debian 11 bullseye environment

### DIFF
--- a/tools/rpi/README.md
+++ b/tools/rpi/README.md
@@ -78,6 +78,16 @@ cd examples_linux/
 python3 getting_started.py # to test and see whether RF24 class can be loaded as module in python correctly
 ```
 
+
+``` for bullseye - Debian 11 on 64 bit operating system
+[ $(lscpu | grep Architecture | awk '{print $2}') != "aarch64" ]] && echo "Not a 64 bit architecture for this step!"
+
+git clone --recurse-submodules https://github.com/nRF24/pyRF24.git
+cd pyRF24
+python -m pip install . -v     # this step takes about 5 minutes!
+```
+
+
 If there are no error messages on the last step, then the NRF24 Wrapper has been installed successfully.
 
 Required python modules

--- a/tools/rpi/ahoy.yml.example
+++ b/tools/rpi/ahoy.yml.example
@@ -31,7 +31,7 @@ ahoy:
     QoS: 0
     Retain: True
     last_will:
-        topic: Appelweg_PV/114181807700     # defaults to 'hoymiles/{serial}'
+        topic: hoymiles/114172220003     # defaults to 'hoymiles/{serial}'
         payload: "LAST-WILL-MESSAGE: Please check my HOST and Process!"
 
   # Influx2 output

--- a/tools/rpi/hoymiles/__init__.py
+++ b/tools/rpi/hoymiles/__init__.py
@@ -11,8 +11,20 @@ import re
 from datetime import datetime
 import logging
 import crcmod
-from RF24 import RF24, RF24_PA_MIN, RF24_PA_LOW, RF24_PA_HIGH, RF24_PA_MAX, RF24_250KBPS, RF24_CRC_DISABLED, RF24_CRC_8, RF24_CRC_16
 from .decoders import *
+
+try:
+  # OSI Layer 2 driver for nRF24L01 on Arduino & Raspberry Pi/Linux Devices
+  # https://github.com/nRF24/RF24.git
+  from RF24 import RF24, RF24_PA_MIN, RF24_PA_LOW, RF24_PA_HIGH, RF24_PA_MAX, RF24_250KBPS, RF24_CRC_DISABLED, RF24_CRC_8, RF24_CRC_16
+except ModuleNotFoundError:
+  try:
+    # Repo for pyRF24 package
+    # https://github.com/nRF24/pyRF24.git
+    from pyrf24 import RF24, RF24_PA_MIN, RF24_PA_LOW, RF24_PA_HIGH, RF24_PA_MAX, RF24_250KBPS, RF24_CRC_DISABLED, RF24_CRC_8, RF24_CRC_16
+  except ModuleNotFoundError:
+    print("Module for RF24 not found - exit")
+    exit()
 
 f_crc_m = crcmod.predefined.mkPredefinedCrcFun('modbus')
 f_crc8 = crcmod.mkCrcFun(0x101, initCrc=0, xorOut=0)


### PR DESCRIPTION
known RF24 lib can not installed on Debian 11 bullseye 64 bit operating system
now, system try to import RF24 nor pyrf24