### PR TITLE
RPI:tuned debug logging and collect data from EventsResponse

### DIFF
--- a/tools/rpi/README.md
+++ b/tools/rpi/README.md
@@ -84,9 +84,14 @@ If there are no error messages on the last step, then the NRF24 Wrapper has been
 Building RF24 Wrapper for Debian 11 (bullseye) 64 bit operating system
 ----------------------------------------------------------------------
 The description above does not work on Debian 11 (bullseye) 64 bit operating system.
-There are 2 possible sollutions to install the RF24 Wrapper.
+Please check first, if you have Debian 11 (bullseye) 64 bit operating system installed:
+ - `uname -a` search for aarch64
+ - `lsb_release -d`
+ - `cat /etc/debian_version`
 
- * `1. solution:`
+There are 2 possible solutions to install the RF24 wrapper:
+
+ * `1. Solution:`
 ```code
 sudo apt install cmake git python3-dev libboost-python-dev python3-pip python3-rpi.gpio
 
@@ -101,13 +106,13 @@ cd RF24
 rm -rf build Makefile.inc 
 ./configure --driver=SPIDEV
 ```
- * edit `Makefile.inc` with your prefered editor e.g. nano or vi
- old:
+ # edit `Makefile.inc` with your prefered editor e.g. nano or vi
+ - old:
 ```code
  CPUFLAGS=-marm -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard
  CFLAGS=-marm -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard -Ofast -Wall -pthread
 ```
- new:
+ - new:
 ```code
  CPUFLAGS=
  CFLAGS=-Ofast -Wall -pthread
@@ -125,8 +130,7 @@ python3 -m pip list #watch for RF24 module - if its there its installed
 ```
 
 
-
- * `2. solution:`
+ * `2. Solution:`
 ```code
 sudo apt install git python3-dev libboost-python-dev python3-pip python3-rpi.gpio
 
@@ -134,6 +138,14 @@ git clone --recurse-submodules https://github.com/nRF24/pyRF24.git
 cd pyRF24
 python3 -m pip install . -v     # this step takes about 5 minutes on my RPI-4 !
 ```
+
+If you have problems with your radio module from ahoi, 
+e.g.: cannot interpret received data,
+please try to reduce the speed of the radio module!
+Add the following line to your ahoy.yml configuration file in "nrf" section:
+* `spispeed: 600000`
+
+
 
 Required python modules
 -----------------------

--- a/tools/rpi/README.md
+++ b/tools/rpi/README.md
@@ -91,7 +91,7 @@ Please check first, if you have Debian 11 (bullseye) 64 bit operating system ins
 
 There are 2 possible solutions to install the RF24 wrapper:
 
- * `1. Solution:`
+**__1. Solution:__**
 ```code
 sudo apt install cmake git python3-dev libboost-python-dev python3-pip python3-rpi.gpio
 
@@ -106,18 +106,19 @@ cd RF24
 rm -rf build Makefile.inc 
 ./configure --driver=SPIDEV
 ```
- # edit `Makefile.inc` with your prefered editor e.g. nano or vi
- - old:
-```code
- CPUFLAGS=-marm -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard
- CFLAGS=-marm -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard -Ofast -Wall -pthread
-```
- - new:
-```code
- CPUFLAGS=
- CFLAGS=-Ofast -Wall -pthread
-```
- * continue with 
+> _edit `Makefile.inc` with your prefered editor e.g. nano or vi_
+> 
+> old:
+>```code
+> CPUFLAGS=-marm -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard
+> CFLAGS=-marm -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard -Ofast -Wall -pthread
+>```
+> new:
+>```code
+> CPUFLAGS=
+> CFLAGS=-Ofast -Wall -pthread
+>```
+_continue now_ 
 ```code
 make
 sudo make install
@@ -130,7 +131,7 @@ python3 -m pip list #watch for RF24 module - if its there its installed
 ```
 
 
- * `2. Solution:`
+**__2. Solution:__**
 ```code
 sudo apt install git python3-dev libboost-python-dev python3-pip python3-rpi.gpio
 
@@ -139,11 +140,10 @@ cd pyRF24
 python3 -m pip install . -v     # this step takes about 5 minutes on my RPI-4 !
 ```
 
-If you have problems with your radio module from ahoi, 
-e.g.: cannot interpret received data,
-please try to reduce the speed of the radio module!
-Add the following line to your ahoy.yml configuration file in "nrf" section:
-* `spispeed: 600000`
+If you have problems with your radio module from ahoi, e.g.: cannot interpret received data, 
+please try to reduce the speed of your radio module!
+Add the following parameter to your ahoy.yml configuration file in "nrf" section:
+`spispeed: 600000` (0.6 MHz)
 
 
 
@@ -247,7 +247,7 @@ Todo
 - Ability to talk to multiple inverters
 - MQTT gateway
 - understand channel hopping
-- configurable polling interval
+- ~~configurable polling interval~~ done: interval ist configurable in ahoy.yml
 - commands
 - picture of setup!
 - python module

--- a/tools/rpi/README.md
+++ b/tools/rpi/README.md
@@ -81,14 +81,58 @@ python3 getting_started.py # to test and see whether RF24 class can be loaded as
 If there are no error messages on the last step, then the NRF24 Wrapper has been installed successfully.
 
 
-for Debian 11 (bullseye) 64 bit operating system
--------------------------------------------------
+Building RF24 Wrapper for Debian 11 (bullseye) 64 bit operating system
+----------------------------------------------------------------------
+The description above does not work on Debian 11 (bullseye) 64 bit operating system.
+There are 2 possible sollutions to install the RF24 Wrapper.
+
+ * `1. solution:`
 ```code
-[ $(lscpu | grep Architecture | awk '{print $2}') != "aarch64" ]] && echo "Not a 64 bit architecture for this step!"
+sudo apt install cmake git python3-dev libboost-python-dev python3-pip python3-rpi.gpio
+
+sudo ln -s $(ls /usr/lib/$(ls /usr/lib/gcc | \
+     head -1)/libboost_python3*.so | \
+     tail -1) /usr/lib/$(ls /usr/lib/gcc | \
+     head -1)/libboost_python3.so
+
+git clone https://github.com/nRF24/RF24.git
+cd RF24
+
+rm -rf build Makefile.inc 
+./configure --driver=SPIDEV
+```
+ * edit `Makefile.inc` with your prefered editor e.g. nano or vi
+ old:
+```code
+ CPUFLAGS=-marm -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard
+ CFLAGS=-marm -march=armv6zk -mtune=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard -Ofast -Wall -pthread
+```
+ new:
+```code
+ CPUFLAGS=
+ CFLAGS=-Ofast -Wall -pthread
+```
+ * continue with 
+```code
+make
+sudo make install
+
+cd pyRF24
+rm -r ./build/ ./dist/ ./RF24.egg-info/ ./__pycache__/ #just to make sure there is no old stuff
+python3 -m pip install --upgrade pip
+python3 -m pip install .
+python3 -m pip list #watch for RF24 module - if its there its installed
+```
+
+
+
+ * `2. solution:`
+```code
+sudo apt install git python3-dev libboost-python-dev python3-pip python3-rpi.gpio
 
 git clone --recurse-submodules https://github.com/nRF24/pyRF24.git
 cd pyRF24
-python -m pip install . -v     # this step takes about 5 minutes!
+python3 -m pip install . -v     # this step takes about 5 minutes on my RPI-4 !
 ```
 
 Required python modules

--- a/tools/rpi/ahoy.service
+++ b/tools/rpi/ahoy.service
@@ -6,11 +6,10 @@
 #   WorkingDirectory         (absolute path to your private ahoy dir)
 # To change other config parameter, please consult systemd documentation
 #
-# To activate this service, create a link, enable and start the ahoy.service
-# $ mkdir -p $HOME/.config/systemd/user 
-# $ ln -sf $(pwd)/ahoy/tools/rpi/ahoy.service -t $HOME/.config/systemd/user
+# To activate this service, create a link with enable and start the ahoy.service
+# $ mkdir -p $HOME/.config/systemd/user
+# $ systemctl --user enable $(pwd)/ahoy/tools/rpi/ahoy.service
 # $ systemctl --user status ahoy
-# $ systemctl --user enable ahoy
 # $ systemctl --user start ahoy
 # $ systemctl --user status ahoy
 #

--- a/tools/rpi/hoymiles/decoders/__init__.py
+++ b/tools/rpi/hoymiles/decoders/__init__.py
@@ -327,9 +327,9 @@ class EventsResponse(UnknownResponse):
             #logging.debug(' payload has valid modbus crc')
             self.response = self.response[:-2]
 
-        status = struct.unpack('>H', self.response[:2])[0]
-        a_text = self.alarm_codes.get(status, 'N/A')
-        logging.info (f' Inverter status: {a_text} ({status})')
+        self.status = struct.unpack('>H', self.response[:2])[0]
+        self.a_text = self.alarm_codes.get(self.status, 'N/A')
+        logging.info (f' Inverter status: {self.a_text} ({self.status})')
 
         chunk_size = 12
         for i_chunk in range(2, len(self.response), chunk_size):
@@ -349,6 +349,14 @@ class EventsResponse(UnknownResponse):
             for fmt in ['BBHHHHH']:
                 dbg += f' {fmt:7}: ' + str(struct.unpack('>' + fmt, chunk))
             logging.debug(dbg)
+
+    def __dict__(self):
+        """ Base values, availabe in each __dict__ call """
+
+        data = super().__dict__()
+        data['inv_stat_num'] = self.status
+        data['inv_stat_txt'] = self.a_text
+        return data
 
 class HardwareInfoResponse(UnknownResponse):
     def __init__(self, *args, **params):
@@ -371,7 +379,6 @@ class HardwareInfoResponse(UnknownResponse):
         """ Base values, availabe in each __dict__ call """
 
         data = super().__dict__()
-        responce_info = self.response
 
         if (len(self.response) != 16):
             logging.error(f'HardwareInfoResponse: data length should be 16 bytes - measured {len(self.response)} bytes')

--- a/tools/rpi/hoymiles/decoders/__init__.py
+++ b/tools/rpi/hoymiles/decoders/__init__.py
@@ -99,6 +99,7 @@ class StatusResponse(Response):
     frequency = None
     powerfactor = None
     event_count = None
+    unpack_error = False
 
     def unpack(self, fmt, base):
         """
@@ -111,6 +112,7 @@ class StatusResponse(Response):
         """
         size = struct.calcsize(fmt)
         if (len(self.response) < base+size):
+           self.unpack_error = True
            logging.error(f'base: {base} size: {size} len: {len(self.response)} fmt: {fmt} rep: {self.response}')
            return [0]
         return struct.unpack(fmt, self.response[base:base+size])
@@ -196,7 +198,8 @@ class StatusResponse(Response):
         data['event_count'] = self.event_count
         data['time'] = self.time_rx
 
-        return data
+        if not self.unpack_error:
+            return data
 
 class UnknownResponse(Response):
     """
@@ -334,12 +337,13 @@ class EventsResponse(UnknownResponse):
 
             logging.debug(' '.join([f'{byte:02x}' for byte in chunk]) + ': ')
 
-            if (len(chunk[0:6]) == 6):
-                opcode, a_code, a_count, uptime_sec = struct.unpack('>BBHH', chunk[0:6])
-                a_text = self.alarm_codes.get(a_code, 'N/A')
-                logging.debug(f' uptime={timedelta(seconds=uptime_sec)} a_count={a_count} opcode={opcode} a_code={a_code} a_text={a_text}')
-            else:
+            if (len(chunk[0:6]) < 6):
                 logging.error(f'length of chunk must be greater or equal 6 bytes: {chunk}')
+                return
+
+            opcode, a_code, a_count, uptime_sec = struct.unpack('>BBHH', chunk[0:6])
+            a_text = self.alarm_codes.get(a_code, 'N/A')
+            logging.debug(f' uptime={timedelta(seconds=uptime_sec)} a_count={a_count} opcode={opcode} a_code={a_code} a_text={a_text}')
 
             dbg = ''
             for fmt in ['BBHHHHH']:
@@ -366,12 +370,15 @@ class HardwareInfoResponse(UnknownResponse):
     def __dict__(self):
         """ Base values, availabe in each __dict__ call """
 
+        data = super().__dict__()
         responce_info = self.response
-        if (len(responce_info) >= 16):
-            logging.info(f'HardwareInfoResponse: {struct.unpack(">HHHHHHHH", responce_info)}')
-        else:
-            logging.error(f'wrong length of HardwareInfoResponse: {responce_info}')
 
+        if (len(self.response) != 16):
+            logging.error(f'HardwareInfoResponse: data length should be 16 bytes - measured {len(self.response)} bytes')
+            logging.error(f'HardwareInfoResponse: data: {self.response}')
+            return data
+
+        logging.info(f'HardwareInfoResponse: {struct.unpack(">HHHHHHHH", self.response[0:16])}')
         fw_version, fw_build_yyyy, fw_build_mmdd, fw_build_hhmm, hw_id = struct.unpack('>HHHHH', self.response[0:10])
 
         fw_version_maj = int((fw_version / 10000))
@@ -385,7 +392,6 @@ class HardwareInfoResponse(UnknownResponse):
                       f'build at {fw_build_dd:>02}/{fw_build_mm:>02}/{fw_build_yyyy}T{fw_build_HH:>02}:{fw_build_MM:>02}, '\
                       f'HW revision {hw_id}')
 
-        data = super().__dict__()
         data['FW_ver_maj'] = fw_version_maj
         data['FW_ver_min'] = fw_version_min
         data['FW_ver_pat'] = fw_version_pat


### PR DESCRIPTION
while preparing RPI-4 for INFLUX 2.0 with Debian 11.6 (bullseye) on 64 bit, I got some trouble. To analyse this trouble, debug logging was tuned and EventsResponse give data back to main.
The cause of trouble on 64bit only, could not analysed exaclty.
As workaround, I had to reduse radio-speed to 0.6 MHz.