### PR TITLE
fixing the chip name on the title page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -32,7 +32,7 @@
         </div>
         <div class="col-lg-7 p-3 p-lg-5 pt-lg-3">
             <h1 class="display-4 fw-bold lh-1">Hardware</h1>
-            <p class="lead">The hardware consists only of two components: ESP8266 and NRF2401L+ module.<br/>
+            <p class="lead">The hardware consists only of two components: ESP8266 and NRF24L01+ module.<br/>
             As a total hardware cost of 10 - 15€ (depends on distributor) it will be the cheapest part of your photovoltaic system.
             The components can be easily soldered together and flashed using our online flash tool</p>
         </div>


### PR DESCRIPTION
On the front page, the chip has a different name than on the following pages. The name will be corrected by the PR.