### PR TITLE
configurable offset for tickMidnight

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -193,7 +193,7 @@ void app::tickNtpUpdate(void) {
             if(mConfig->inst.rstValsNotAvail)
                 everyMin(std::bind(&app::tickMinute, this), "tMin");
             if(mConfig->inst.rstYieldMidNight) {
-                uint32_t midTrig = mTimestamp - ((mTimestamp - 1) % 86400) + 86400; // next midnight
+                uint32_t midTrig = mTimestamp - ((mTimestamp + MIDNIGHTTICKER_OFFSET) % 86400) + 86400; // next midnight
                 onceAt(std::bind(&app::tickMidnight, this), midTrig, "midNi");
             }
         }
@@ -304,7 +304,7 @@ void app::tickMinute(void) {
 //-----------------------------------------------------------------------------
 void app::tickMidnight(void) {
     // only triggered if 'reset values at midnight is enabled'
-    uint32_t nxtTrig = mTimestamp - ((mTimestamp - 1) % 86400) + 86400; // next midnight
+    uint32_t nxtTrig = mTimestamp - ((mTimestamp + MIDNIGHTTICKER_OFFSET) % 86400) + 86400; // next midnight
     onceAt(std::bind(&app::tickMidnight, this), nxtTrig, "mid2");
 
     Inverter<> *iv;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -122,6 +122,13 @@
 // reconnect delay
 #define MQTT_RECONNECT_DELAY    5000
 
+// Offset for midnight Ticker
+// relative to UTC
+//   may be negative for later in the next day or positive for earlier in previous day
+//   may contain variable like mCalculatedTimezoneOffset
+// must be in parentheses
+#define MIDNIGHTTICKER_OFFSET (-1)
+
 #if __has_include("config_override.h")
     #include "config_override.h"
 #endif

--- a/src/config/config_override_example.h
+++ b/src/config/config_override_example.h
@@ -26,6 +26,10 @@
 #define DEF_RF24_IRQ_PIN        16
 
 
+// Offset for midnight Ticker Example: 1 second before midnight (local time)
+#undef MIDNIGHTTICKER_OFFSET
+#define MIDNIGHTTICKER_OFFSET (mCalculatedTimezoneOffset + 1)
+
 // To enable the json endpoint at /json
 // #define ENABLE_JSON_EP
 


### PR DESCRIPTION
Vorschlag für eine Möglichkeit den Mitternachtspunkt beim Übersetzen konfigurieren zu können.
Siehe #697 