### PR TITLE
Code cleanup: remove obsolete JSON_EP

### DIFF
--- a/src/config/config_override_example.h
+++ b/src/config/config_override_example.h
@@ -30,9 +30,6 @@
 #undef MIDNIGHTTICKER_OFFSET
 #define MIDNIGHTTICKER_OFFSET (mCalculatedTimezoneOffset + 1)
 
-// To enable the json endpoint at /json
-// #define ENABLE_JSON_EP
-
 // To enable the endpoint for prometheus to scrape data from at /metrics
 // #define ENABLE_PROMETHEUS_EP
 

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -75,9 +75,6 @@ class Web {
             mWeb.on("/live",           HTTP_ANY,  std::bind(&Web::onLive,         this, std::placeholders::_1));
             //mWeb.on("/api1",           HTTP_POST, std::bind(&Web::showWebApi,     this, std::placeholders::_1));
 
-        #ifdef ENABLE_JSON_EP
-            mWeb.on("/json",           HTTP_ANY,  std::bind(&Web::showJson,       this, std::placeholders::_1));
-        #endif
         #ifdef ENABLE_PROMETHEUS_EP
             mWeb.on("/metrics",        HTTP_ANY,  std::bind(&Web::showMetrics,    this, std::placeholders::_1));
         #endif
@@ -730,36 +727,6 @@ class Web {
             request->send(response);
         }
 
-#ifdef ENABLE_JSON_EP
-        void showJson(AsyncWebServerRequest *request) {
-            DPRINTLN(DBG_VERBOSE, F("web::showJson"));
-            String modJson;
-            Inverter<> *iv;
-            record_t<> *rec;
-                char topic[40], val[25];
-
-            modJson = F("{\n");
-            for(uint8_t id = 0; id < mSys->getNumInverters(); id++) {
-                iv = mSys->getInverterByPos(id);
-                if(NULL == iv)
-                    continue;
-
-                rec = iv->getRecordStruct(RealTimeRunData_Debug);
-                snprintf(topic, 30, "\"%s\": {\n", iv->config->name);
-                modJson += String(topic);
-                for(uint8_t i = 0; i < rec->length; i++) {
-                    snprintf(topic, 40, "\t\"ch%d/%s\"", rec->assign[i].ch, iv->getFieldName(i, rec));
-                    snprintf(val, 25, "[%.3f, \"%s\"]", iv->getValue(i, rec), iv->getUnit(i, rec));
-                    modJson += String(topic) + ": " + String(val) + F(",\n");
-                }
-                modJson += F("\t\"last_msg\": \"") + ah::getDateTimeStr(rec->ts) + F("\"\n\t},\n");
-            }
-            modJson += F("\"json_ts\": \"") + String(ah::getDateTimeStr(mApp->getTimestamp())) + F("\"\n}\n");
-
-            AsyncWebServerResponse *response = request->beginResponse(200, F("application/json"), modJson);
-            request->send(response);
-        }
-#endif
 
 #ifdef ENABLE_PROMETHEUS_EP
         enum {


### PR DESCRIPTION
Wie auch schon von @avendretter vorgeschlagen kann der JSON Endpoint eigentlich von der Codebasis entfernt werden.
Die Funktionalität ist vollkommen/besser durch die API abgedeckt.