### PR TITLE
MQTT topic was ignored

### DIFF
--- a/tools/rpi/hoymiles/outputs.py
+++ b/tools/rpi/hoymiles/outputs.py
@@ -210,7 +210,8 @@ class MqttOutputPlugin(OutputPluginFactory):
         """
 
         data = response.__dict__()
-        topic = f'{data.get("inverter_name", "hoymiles")}/{data.get("inverter_ser", None)}'
+        #topic = f'{data.get("inverter_name", "hoymiles")}/{data.get("inverter_ser", None)}'
+        topic = params.get('topic', f'{data.get("inverter_name", "hoymiles")}/{data.get("inverter_ser", None)}')
 
         if isinstance(response, StatusResponse):
 


### PR DESCRIPTION
The used MQTT topic set in the config file has been ignored and another default topic was used instead. Now the configured topic is being used and just in case of errors, the previous default topic. 