### PR TITLE
Add uptime and RSSI to Prometheus metrics

### DIFF
--- a/doc/prometheus_ep_description.md
+++ b/doc/prometheus_ep_description.md
@@ -18,6 +18,8 @@ Prometheus metrics provided at `/metrics`.
 | Metric name                            | Type    | Description                                            | Labels       | 
 |----------------------------------------|---------|--------------------------------------------------------|--------------|
 | `ahoy_solar_info`                      | Gauge   | Information about the AhoyDTU device                   | version, image, devicename |
+| `ahoy_solar_uptime`                    | Counter | Seconds since boot of the AhoyDTU device               | devicename |
+| `ahoy_solar_rssi_db`                   | Gauge   | Quality of the Wifi STA connection                     | devicename |
 | `ahoy_solar_inverter_info`             | Gauge   | Information about the configured inverter(s)           | name, serial |
 | `ahoy_solar_inverter_enabled`          | Gauge   | Is the inverter enabled?                               | inverter  |
 | `ahoy_solar_inverter_is_available`     | Gauge   | is the inverter available?                             | inverter  |

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -689,6 +689,10 @@ class Web {
                         snprintf(topic,sizeof(topic),"ahoy_solar_uptime{devicename=\"%s\"} %u\n", mConfig->sys.deviceName, mApp->getUptime());
                         metrics += String(type) + String(topic);
 
+                        snprintf(type,sizeof(type),"# TYPE ahoy_solar_wifi_rssi_db gauge\n");
+                        snprintf(topic,sizeof(topic),"ahoy_solar_wifi_rssi_db{devicename=\"%s\"} %d\n", mConfig->sys.deviceName, WiFi.RSSI());
+                        metrics += String(type) + String(topic);
+
                         // NRF Statistics
                         stat = mApp->getStatistics();
                         metrics += radioStatistic(F("rx_success"),     stat->rxSuccess);

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -686,7 +686,7 @@ class Web {
                         metrics += String(type) + String(topic);
 
                         snprintf(type,sizeof(type),"# TYPE ahoy_solar_uptime counter\n");
-                        snprintf(topic,sizeof(topic),"ahoy_solar_uptime{devicename=\"%s\"} %u\n", mApp->getUptime());
+                        snprintf(topic,sizeof(topic),"ahoy_solar_uptime{devicename=\"%s\"} %u\n", mConfig->sys.deviceName, mApp->getUptime());
                         metrics += String(type) + String(topic);
 
                         // NRF Statistics

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -681,8 +681,13 @@ class Web {
                             mApp->getVersion(), mConfig->sys.deviceName);
                         metrics = String(type) + String(topic);
 
-                        snprintf(topic,sizeof(topic),"# TYPE ahoy_solar_freeheap gauge\nahoy_solar_freeheap{devicename=\"%s\"} %u\n",mConfig->sys.deviceName,ESP.getFreeHeap());
-                        metrics += String(topic);
+                        snprintf(type,sizeof(type),"# TYPE ahoy_solar_freeheap gauge\n");
+                        snprintf(topic,sizeof(topic),"ahoy_solar_freeheap{devicename=\"%s\"} %u\n",mConfig->sys.deviceName,ESP.getFreeHeap());
+                        metrics += String(type) + String(topic);
+
+                        snprintf(type,sizeof(type),"# TYPE ahoy_solar_uptime counter\n");
+                        snprintf(topic,sizeof(topic),"ahoy_solar_uptime{devicename=\"%s\"} %u\n", mApp->getUptime());
+                        metrics += String(type) + String(topic);
 
                         // NRF Statistics
                         stat = mApp->getStatistics();
@@ -789,7 +794,7 @@ class Web {
 
         String radioStatistic(String statistic, uint32_t value) {
             char type[60], topic[80], val[25];
-            snprintf(type, sizeof(type), "# TYPE ahoy_solar_radio_%s gauge",statistic.c_str());
+            snprintf(type, sizeof(type), "# TYPE ahoy_solar_radio_%s counter",statistic.c_str());
             snprintf(topic, sizeof(topic), "ahoy_solar_radio_%s",statistic.c_str());
             snprintf(val, sizeof(val), "%d", value);
             return ( String(type) + "\n" + String(topic) + " " + String(val) + "\n");


### PR DESCRIPTION
The uptime and RSSI metric are useful also for Prometheus.

I also changed the radio metrics to `counter` type since that is what they do.