### PR TITLE
Fix for issue #828, browser caching, versioned URLs and reordered CSS/JS includes

### DIFF
--- a/src/web/html/includes/header.html
+++ b/src/web/html/includes/header.html
@@ -1,5 +1,5 @@
-<link rel="stylesheet" type="text/css" href="colors.css"/>
-<link rel="stylesheet" type="text/css" href="style.css"/>
+<link rel="stylesheet" type="text/css" href="style.css?v={#VERSION}"/>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta charset="UTF-8">
-<script type="text/javascript" src="api.js"></script>
+<script type="text/javascript" src="api.js?v={#VERSION}"></script>
+<link rel="stylesheet" type="text/css" href="colors.css?v={#VERSION}"/>

--- a/src/web/html/includes/nav.html
+++ b/src/web/html/includes/nav.html
@@ -1,21 +1,21 @@
 <div class="topnav">
-    <a href="/" class="title">AhoyDTU</a>
+    <a href="/?v={#VERSION}" class="title">AhoyDTU</a>
     <a href="javascript:void(0);" class="icon" onclick="topnav()">
         <span></span>
         <span></span>
         <span></span>
     </a>
     <div id="topnav" class="mobile">
-        <a id="nav3" class="hide" href="/live">Live</a>
-        <a id="nav4" class="hide" href="/serial">Serial / Control</a>
-        <a id="nav5" class="hide" href="/setup">Settings</a>
+        <a id="nav3" class="hide" href="/live?v={#VERSION}">Live</a>
+        <a id="nav4" class="hide" href="/serial?v={#VERSION}">Serial / Control</a>
+        <a id="nav5" class="hide" href="/setup?v={#VERSION}">Settings</a>
         <span class="seperator"></span>
-        <a id="nav6" class="hide" href="/update">Update</a>
-        <a id="nav7" class="hide" href="/system">System</a>
+        <a id="nav6" class="hide" href="/update?v={#VERSION}">Update</a>
+        <a id="nav7" class="hide" href="/system?v={#VERSION}">System</a>
         <span class="seperator"></span>
         <a id="nav8" href="/api" target="_blank">REST API</a>
         <a id="nav9" href="https://ahoydtu.de" target="_blank">Documentation</a>
-        <a id="nav10" href="/about">About</a>
+        <a id="nav10" href="/about?v={#VERSION}">About</a>
         <span class="seperator"></span>
         <a id="nav0" class="hide" href="/login">Login</a>
         <a id="nav1" class="hide" href="/logout">Logout</a>

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -320,7 +320,6 @@ class Web {
 
         void onLogin(AsyncWebServerRequest *request) {
             DPRINTLN(DBG_VERBOSE, F("onLogin"));
-            DPRINTLN(DBG_WARN, String(mConfig->sys.adminPwd));
 
             if (request->args() > 0) {
                 if (String(request->arg("pwd")) == String(mConfig->sys.adminPwd)) {

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -255,6 +255,9 @@ class Web {
 
             AsyncWebServerResponse *response = request->beginResponse_P(200, F("text/html; charset=UTF-8"), update_html, update_html_len);
             response->addHeader(F("Content-Encoding"), "gzip");
+            if(request->hasParam("v")) {
+                response->addHeader(F("Cache-Control"), F("max-age=604800"));
+            }
             request->send(response);
         }
 
@@ -309,11 +312,15 @@ class Web {
 
             AsyncWebServerResponse *response = request->beginResponse_P(200, F("text/html; charset=UTF-8"), index_html, index_html_len);
             response->addHeader(F("Content-Encoding"), "gzip");
+            if(request->hasParam("v")) {
+                response->addHeader(F("Cache-Control"), F("max-age=604800"));
+            }
             request->send(response);
         }
 
         void onLogin(AsyncWebServerRequest *request) {
             DPRINTLN(DBG_VERBOSE, F("onLogin"));
+            DPRINTLN(DBG_WARN, String(mConfig->sys.adminPwd));
 
             if (request->args() > 0) {
                 if (String(request->arg("pwd")) == String(mConfig->sys.adminPwd)) {
@@ -348,6 +355,9 @@ class Web {
             else
                 response = request->beginResponse_P(200, F("text/css"), colorBright_css, colorBright_css_len);
             response->addHeader(F("Content-Encoding"), "gzip");
+            if(request->hasParam("v")) {
+                response->addHeader(F("Cache-Control"), F("max-age=604800"));
+            }
             request->send(response);
         }
 
@@ -356,6 +366,9 @@ class Web {
             mLogoutTimeout = LOGOUT_TIMEOUT;
             AsyncWebServerResponse *response = request->beginResponse_P(200, F("text/css"), style_css, style_css_len);
             response->addHeader(F("Content-Encoding"), "gzip");
+            if(request->hasParam("v")) {
+                response->addHeader(F("Cache-Control"), F("max-age=604800"));
+            }
             request->send(response);
         }
 
@@ -364,6 +377,9 @@ class Web {
 
             AsyncWebServerResponse *response = request->beginResponse_P(200, F("text/javascript"), api_js, api_js_len);
             response->addHeader(F("Content-Encoding"), "gzip");
+            if(request->hasParam("v")) {
+                response->addHeader(F("Cache-Control"), F("max-age=604800"));
+            }
             request->send(response);
         }
 
@@ -429,6 +445,9 @@ class Web {
 
             AsyncWebServerResponse *response = request->beginResponse_P(200, F("text/html; charset=UTF-8"), setup_html, setup_html_len);
             response->addHeader(F("Content-Encoding"), "gzip");
+            if(request->hasParam("v")) {
+                response->addHeader(F("Cache-Control"), F("max-age=604800"));
+            }
             request->send(response);
         }
 
@@ -604,6 +623,9 @@ class Web {
             AsyncWebServerResponse *response = request->beginResponse_P(200, F("text/html; charset=UTF-8"), visualization_html, visualization_html_len);
             response->addHeader(F("Content-Encoding"), "gzip");
             response->addHeader(F("content-type"), "text/html; charset=UTF-8");
+            if(request->hasParam("v")) {
+                response->addHeader(F("Cache-Control"), F("max-age=604800"));
+            }
 
             request->send(response);
         }
@@ -612,6 +634,9 @@ class Web {
             AsyncWebServerResponse *response = request->beginResponse_P(200, F("text/html; charset=UTF-8"), about_html, about_html_len);
             response->addHeader(F("Content-Encoding"), "gzip");
             response->addHeader(F("content-type"), "text/html; charset=UTF-8");
+            if(request->hasParam("v")) {
+                response->addHeader(F("Cache-Control"), F("max-age=604800"));
+            }
 
             request->send(response);
         }
@@ -630,6 +655,9 @@ class Web {
 
             AsyncWebServerResponse *response = request->beginResponse_P(200, F("text/html; charset=UTF-8"), serial_html, serial_html_len);
             response->addHeader(F("Content-Encoding"), "gzip");
+            if(request->hasParam("v")) {
+                response->addHeader(F("Cache-Control"), F("max-age=604800"));
+            }
             request->send(response);
         }
 
@@ -641,6 +669,9 @@ class Web {
 
             AsyncWebServerResponse *response = request->beginResponse_P(200, F("text/html; charset=UTF-8"), system_html, system_html_len);
             response->addHeader(F("Content-Encoding"), "gzip");
+            if(request->hasParam("v")) {
+                response->addHeader(F("Cache-Control"), F("max-age=604800"));
+            }
             request->send(response);
         }
 


### PR DESCRIPTION
I added cache headers to all static resources to get around the low heap problems mentioned in issue #828. Since the static resources are now being cached, the browser only needs to download these resources once, which reduces the number of requests and fixes the heap exhaustion problems. It also improves loading times when navigating inside Ahoy.

I reordered the CSS/JS includes in the header file so colors.css would be loaded last. If a request fails due to low heap issues, it's better that the color scheme fails to load rather than the JS file.

A version parameter was added to the URLs of static files so the browser wouldn't continue using stale versions of these files after an Ahoy upgrade.