### PR TITLE
Fix padding of title in mobile view

### DIFF
--- a/src/web/html/style.css
+++ b/src/web/html/style.css
@@ -92,7 +92,7 @@ svg.icon {
 .title {
     background-color: var(--primary);
     color: #fff !important;
-    padding-left: 80px !important
+    padding: 15px 14px 16px 80px !important
 }
 
 .topnav .icon span {


### PR DESCRIPTION
I think it looks better when the burger menu and the title bar in mobile view have the same hight.