### PR TITLE
Several improvements and bugfixes around saving settings

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -92,6 +92,10 @@ class app : public IApp, public ah::Scheduler {
             return mSettings.getLastSaveSucceed();
         }
 
+        bool getShouldReboot() {
+            return mSaveReboot;
+        }
+
         statistics_t *getStatistics() {
             return &mStat;
         }

--- a/src/appInterface.h
+++ b/src/appInterface.h
@@ -20,6 +20,7 @@ class IApp {
         virtual bool eraseSettings(bool eraseWifi) = 0;
         virtual bool getSavePending() = 0;
         virtual bool getLastSaveSucceed() = 0;
+        virtual bool getShouldReboot() = 0;
         virtual void setOnUpdate() = 0;
         virtual void setRebootFlag() = 0;
         virtual const char *getVersion() = 0;

--- a/src/web/RestApi.h
+++ b/src/web/RestApi.h
@@ -276,6 +276,7 @@ class RestApi {
             getGeneric(request, obj.createNestedObject(F("generic")));
             obj["pending"] = (bool)mApp->getSavePending();
             obj["success"] = (bool)mApp->getLastSaveSucceed();
+            obj["reboot"] = (bool)mApp->getShouldReboot();
         }
 
         void getReboot(AsyncWebServerRequest *request, JsonObject obj) {

--- a/src/web/html/api.js
+++ b/src/web/html/api.js
@@ -103,9 +103,11 @@ function parseVersion(obj) {
 }
 
 function parseESP(obj) {
-    document.getElementById("esp_type").append(
-        document.createTextNode("Board: " + obj["esp_type"])
-    );
+    if(document.getElementById("esp_type").childNodes.length < 1) {
+        document.getElementById("esp_type").append(
+            document.createTextNode("Board: " + obj["esp_type"])
+        );
+    }
 }
 
 function parseRssi(obj) {

--- a/src/web/html/save.html
+++ b/src/web/html/save.html
@@ -8,11 +8,14 @@
         {#HTML_NAV}
         <div id="wrapper">
             <div id="content">
-                <div id="html" class="mt-3 mb-3"></div>
+                <div id="html" class="mt-3 mb-3">Saving settings...</div>
             </div>
         </div>
         {#HTML_FOOTER}
         <script type="text/javascript">
+
+            var intervalId = null;
+
             function parseGeneric(obj) {
                 parseNav(obj);
                 parseESP(obj);
@@ -22,17 +25,27 @@
             function parseHtml(obj) {
                 var html = "";
                 if(obj.pending)
-                    html = "saving settings ...";
+                    html = "Saving settings ...";
                 else {
-                    if(obj.success)
-                        html = "settings successfully saved";
-                    else
-                        html = "failed saving settings";
-
-                    var meta = document.createElement('meta');
-                    meta.httpEquiv = "refresh"
-                    meta.content = 1 + "; URL=/setup";
-                    document.getElementsByTagName('head')[0].appendChild(meta);
+                    if(intervalId != null) {
+                        clearInterval(intervalId);
+                    }
+                    if(obj.success) {
+                        var meta = document.createElement('meta');
+                        meta.httpEquiv = "refresh"
+                        if(!obj.reboot) {
+                            html = "Settings successfully saved. Automatic page reload in 3 seconds.";
+                            meta.content = 3;
+                        }
+                        else {
+                            html = "Settings successfully saved. Rebooting. Automatic redirect in 20 seconds.";
+                            meta.content = 20 + "; URL=/";
+                        }
+                        document.getElementsByTagName('head')[0].appendChild(meta);
+                    }
+                    else {
+                        html = "Failed saving settings.";
+                    }
                 }
                 document.getElementById("html").innerHTML = html;
             }
@@ -41,11 +54,9 @@
                 if(null != obj) {
                     parseGeneric(obj["generic"]);
                     parseHtml(obj);
-                    window.setInterval("getAjax('/api/html/save', parse)", 1100);
                 }
             }
-
-            getAjax("/api/html/save", parse);
+           intervalId =  window.setInterval("getAjax('/api/html/save', parse)", 2500);
         </script>
     </body>
 </html>

--- a/src/web/html/setup.html
+++ b/src/web/html/setup.html
@@ -31,7 +31,7 @@
                         <div class="row mb-3">
                             <div class="col-8 col-sm-3">Dark Mode</div>
                             <div class="col-4 col-sm-9"><input type="checkbox" name="darkMode"/></div>
-                            <div class="col-8 col-sm-3">(empty browser cache or use Shift + F5 after reboot to apply this setting)</div>
+                            <div class="col-8 col-sm-3">(empty browser cache or use CTRL + F5 after reboot to apply this setting)</div>
                         </div>
                     </fieldset>
                     <fieldset class="mb-4">

--- a/src/web/html/setup.html
+++ b/src/web/html/setup.html
@@ -31,6 +31,7 @@
                         <div class="row mb-3">
                             <div class="col-8 col-sm-3">Dark Mode</div>
                             <div class="col-4 col-sm-9"><input type="checkbox" name="darkMode"/></div>
+                            <div class="col-8 col-sm-3">(empty browser cache or use Shift + F5 after reboot to apply this setting)</div>
                         </div>
                     </fieldset>
                     <fieldset class="mb-4">

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -515,7 +515,7 @@ class Web {
 
             // pinout
             uint8_t pin;
-            for (uint8_t i = 0; i < 8; i++) {
+            for (uint8_t i = 0; i < 9; i++) {
                 pin = request->arg(String(pinArgNames[i])).toInt();
                 switch(i) {
                     default: mConfig->nrf.pinCs    = ((pin != 0xff) ? pin : DEF_CS_PIN);  break;


### PR DESCRIPTION
Bugfix 1:

LED Active High/Low now gets saved properly.

Bugfix 2:

This is a pretty severe bug, and possibly the reason why the ESP would sometimes crash or not save settings properly.

When saving settings the browser would start a 1.1 second timer and send periodic API requests to check the save status. Each response would start another 1.1 second timer that would also make API requests, and those responses would spawn new timers...
Basically, the number of requests would grow exponentially and within a few seconds the browser would be hammering the ESP with 4 or 8 parallel API requests while it was busy saving the settings, exhausting the heap memory.
I changed the JS so it would not spawn additional timers and I changed the delay to a better value. There's no point in checking after 1.1 seconds because saving the data always takes a little over 2 seconds, so a 2.5 second timer works well. This also gives the ESP more time to save settings without having to respond to API requests at the same time. This could potentially lead to corrupted settings.

Bugfix 3:

Each of those API responses would append 'Board: ESP8266' in the footer of the website, so after a few seconds it would say something like 'Board: ESP8266Board: ESP8266Board: ESP8266Board: ESP8266Board: ESP8266'. I changed the JS to prevent that.

Improvement 1:

While saving settings, the page now shows when the operation is in progress and it tells the user whether saving succeeded or not. It will also either refresh the page after 3 seconds (when reboot is disabled) or redirect to the index after 20 seconds if the ESP is rebooting. Previously it would sort of crash to a blank error page after saving.

Improvement 2:

Since CSS files are now being cached, changing between dark/light modes requires emptying the browser cache. I added a note to the settings page about that.