### PR TITLE
Added option to reboot Ahoy every 24 hours

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -193,6 +193,14 @@ void app::tickNtpUpdate(void) {
                 uint32_t midTrig = gTimezone.toUTC(localTime - (localTime % 86400) + 86400);  // next midnight local time
                 onceAt(std::bind(&app::tickMidnight, this), midTrig, "midNi");
             }
+            if (mConfig->sys.schedReboot) {
+                uint32_t localTime = gTimezone.toLocal(mTimestamp);
+                uint32_t rebootTrig = gTimezone.toUTC(localTime - (localTime % 86400) + 86410);  // reboot 10 secs after midnght
+                if (rebootTrig <= mTimestamp) { //necessary for times other than midnight to prevent reboot loop
+                   rebootTrig += 86400;
+                }
+                onceAt(std::bind(&app::tickReboot, this), rebootTrig, "midRe");
+            }
         }
 
         nxtTrig = isOK ? 43200 : 60;  // depending on NTP update success check again in 12 h or in 1 min

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -64,6 +64,7 @@ typedef struct {
     char adminPwd[PWD_LEN];
     uint16_t protectionMask;
     bool darkMode;
+    bool schedReboot;
 
     // wifi
     char stationSsid[SSID_LEN];
@@ -338,6 +339,7 @@ class settings {
             mCfg.sys.protectionMask = DEF_PROT_INDEX | DEF_PROT_LIVE | DEF_PROT_SERIAL | DEF_PROT_SETUP
                                     | DEF_PROT_UPDATE | DEF_PROT_SYSTEM | DEF_PROT_API | DEF_PROT_MQTT;
             mCfg.sys.darkMode = false;
+            mCfg.sys.schedReboot = true;
             // restore temp settings
             if(keepWifi)
                 memcpy(&mCfg.sys, &tmp, sizeof(cfgSys_t));
@@ -409,6 +411,7 @@ class settings {
                 obj[F("adm")]  = mCfg.sys.adminPwd;
                 obj[F("prot_mask")] = mCfg.sys.protectionMask;
                 obj[F("dark")] = mCfg.sys.darkMode;
+                obj[F("reb")] = mCfg.sys.schedReboot;
                 ah::ip2Char(mCfg.sys.ip.ip, buf);      obj[F("ip")]   = String(buf);
                 ah::ip2Char(mCfg.sys.ip.mask, buf);    obj[F("mask")] = String(buf);
                 ah::ip2Char(mCfg.sys.ip.dns1, buf);    obj[F("dns1")] = String(buf);
@@ -421,6 +424,7 @@ class settings {
                 getChar(obj, F("adm"), mCfg.sys.adminPwd, PWD_LEN);
                 getVal<uint16_t>(obj, F("prot_mask"), &mCfg.sys.protectionMask);
                 getVal<bool>(obj, F("dark"), &mCfg.sys.darkMode);
+                getVal<bool>(obj, F("reb"), &mCfg.sys.schedReboot);
                 if(obj.containsKey(F("ip"))) ah::ip2Arr(mCfg.sys.ip.ip,      obj[F("ip")].as<const char*>());
                 if(obj.containsKey(F("mask"))) ah::ip2Arr(mCfg.sys.ip.mask,    obj[F("mask")].as<const char*>());
                 if(obj.containsKey(F("dns1"))) ah::ip2Arr(mCfg.sys.ip.dns1,    obj[F("dns1")].as<const char*>());

--- a/src/web/RestApi.h
+++ b/src/web/RestApi.h
@@ -207,6 +207,7 @@ class RestApi {
             obj[F("ssid")]         = mConfig->sys.stationSsid;
             obj[F("device_name")]  = mConfig->sys.deviceName;
             obj[F("dark_mode")]    = (bool)mConfig->sys.darkMode;
+            obj[F("sched_reboot")]    = (bool)mConfig->sys.schedReboot;
 
             obj[F("mac")]          = WiFi.macAddress();
             obj[F("hostname")]     = mConfig->sys.deviceName;

--- a/src/web/html/setup.html
+++ b/src/web/html/setup.html
@@ -29,6 +29,10 @@
                             <div class="col-12 col-sm-9"><input type="text" name="device"/></div>
                         </div>
                         <div class="row mb-3">
+                            <div class="col-8 col-sm-3">Reboot Ahoy at midnight</div>
+                            <div class="col-4 col-sm-9"><input type="checkbox" name="schedReboot"/></div>
+                        </div>
+                        <div class="row mb-3">
                             <div class="col-8 col-sm-3">Dark Mode</div>
                             <div class="col-4 col-sm-9"><input type="checkbox" name="darkMode"/></div>
                             <div class="col-8 col-sm-3">(empty browser cache or use CTRL + F5 after reboot to apply this setting)</div>
@@ -606,6 +610,7 @@
                 for(var i of [["device", "device_name"], ["ssid", "ssid"]])
                     document.getElementsByName(i[0])[0].value = obj[i[1]];
                 document.getElementsByName("darkMode")[0].checked = obj["dark_mode"];
+                document.getElementsByName("schedReboot")[0].checked = obj["sched_reboot"];
                 e = document.getElementsByName("adminpwd")[0];
                 if(!obj["pwd_set"])
                     e.value = "";

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -451,6 +451,7 @@ class Web {
             if (request->arg("device") != "")
                 request->arg("device").toCharArray(mConfig->sys.deviceName, DEVNAME_LEN);
             mConfig->sys.darkMode = (request->arg("darkMode") == "on");
+            mConfig->sys.schedReboot = (request->arg("schedReboot") == "on");
 
             // protection
             if (request->arg("adminpwd") != "{PWD}") {


### PR DESCRIPTION
I've spent a fair bit of time looking at ways to improve the stability of Ahoy and to prevent heap fragmentation. What I have learned is that a number of libraries we use allocate memory dynamically, and that heap fragmentation is unavoidable as long as Ahoy needs to communicate via protocols such as JSON, Prometheus, MQTT etc.

If heap fragmentation cannot be avoided (even with zero dynamic allocation on our end) and it cannot be fixed, that only leaves two options:
1. Wait for the ESP to crash after a while and for the watchdog to reset it (hopefully).
2. Restart the ESP at a scheduled time to clean up the heap.

I can't think of any scenario in which the first option would be preferable, so I would also argue that the scheduled reboot option should be enabled by default. I don't think a 10 second restart at night would really be a problem for anyone, but random crashes or certain functions becoming unavailable while running certainly are.