### PR TITLE
Fix suntimes working if mqtt is enabled but suntimes is disabled

### DIFF
--- a/tools/rpi/hoymiles/__main__.py
+++ b/tools/rpi/hoymiles/__main__.py
@@ -101,7 +101,7 @@ class SunsetHandler:
                 logging.info (f'Woke up...')
 
     def sun_status2mqtt(self, dtu_ser, dtu_name):
-        if not mqtt_client:
+        if not mqtt_client or not self.suntimes:
             return
         local_sunrise = self.suntimes.riselocal(datetime.now()).strftime("%d.%m.%YT%H:%M")
         local_sunset = self.suntimes.setlocal(datetime.now()).strftime("%d.%m.%YT%H:%M")


### PR DESCRIPTION
I think the fix is pretty obvious.

In my case I need mqtt enabled but sunset disabled (zero feed-in). In that case the execution blocks and does not work anymore.