### PR TITLE
Implemented quick fix for #889 from anorak-47

### DIFF
--- a/src/publisher/pubMqtt.h
+++ b/src/publisher/pubMqtt.h
@@ -314,7 +314,9 @@ class PubMqtt {
                 delete[] pyld;
             }
 
-            const char *p = topic;
+            # quick fix for #889
+            # initial line: const char *p = topic;
+            const char *p = topic + strlen(mCfgMqtt->topic);
             uint8_t pos = 0;
             uint8_t elm = 0;
             char tmp[30];


### PR DESCRIPTION
#889 et al. spotted the behaviour a power limit cannot be set via mqtt when the mqtt prefix chosen in the ahoy config is nested.
@anorak-47 mentioned a quick fix in the discussion, but before merging a short quality check by the "pros" of ahoy is needed because we don't know whether the quick fix has any side effects.

Thank you!