### PR TITLE
Fixed index out of bounds

### DIFF
--- a/tools/rpi/hoymiles/decoders/__init__.py
+++ b/tools/rpi/hoymiles/decoders/__init__.py
@@ -154,15 +154,16 @@ class StatusResponse(Response):
         while s_exists:
             s_exists = False
             string_id = len(strings)
-            string = {}
-            string['name'] = self.inv_strings[string_id]['s_name']
-            for key in self.string_keys:
-                prop = f'dc_{key}_{string_id}'
-                if hasattr(self, prop):
-                    s_exists = True
-                    string[key] = getattr(self, prop)
-            if s_exists:
-                strings.append(string)
+            if string_id < len(self.inv_strings):
+              string = {}
+              string['name'] = self.inv_strings[string_id]['s_name']
+              for key in self.string_keys:
+                  prop = f'dc_{key}_{string_id}'
+                  if hasattr(self, prop):
+                      s_exists = True
+                      string[key] = getattr(self, prop)
+              if s_exists:
+                  strings.append(string)
 
         return strings
 


### PR DESCRIPTION
The "tool" crashs if the size of the inverter is equal to the "real" inverter.

```
pi@rhino:~/ahoy/tools/rpi $ python3 -um hoymiles --log-transactions --verbose --config ahoy.yml
No module named 'RF24' - try to use module: RF24
No module named 'RF24' - Using python Module: pyrf24
<hoymiles.decoders.Hm600Decode0B object at 0x760061f0>
Traceback (most recent call last):
  File "/home/pi/ahoy/tools/rpi/hoymiles/__main__.py", line 148, in main_loop
    poll_inverter(inverter, dtu_ser, do_init, transmit_retries)
  File "/home/pi/ahoy/tools/rpi/hoymiles/__main__.py", line 228, in poll_inverter
    logging.info(f'Decoded: {result.__dict__()}')
  File "/home/pi/ahoy/tools/rpi/hoymiles/decoders/__init__.py", line 179, in __dict__
    data['strings'] = self.strings
  File "/home/pi/ahoy/tools/rpi/hoymiles/decoders/__init__.py", line 159, in strings
    string['name'] = self.inv_strings[string_id]['s_name']
IndexError: list index out of range
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/pi/ahoy/tools/rpi/hoymiles/__main__.py", line 410, in <module>
    main_loop(ahoy_config)
  File "/home/pi/ahoy/tools/rpi/hoymiles/__main__.py", line 148, in main_loop
    poll_inverter(inverter, dtu_ser, do_init, transmit_retries)
  File "/home/pi/ahoy/tools/rpi/hoymiles/__main__.py", line 228, in poll_inverter
    logging.info(f'Decoded: {result.__dict__()}')
  File "/home/pi/ahoy/tools/rpi/hoymiles/decoders/__init__.py", line 179, in __dict__
    data['strings'] = self.strings
  File "/home/pi/ahoy/tools/rpi/hoymiles/decoders/__init__.py", line 159, in strings
    string['name'] = self.inv_strings[string_id]['s_name']
IndexError: list index out of range
```