### PR TITLE
RPi:crash when using additional InfoCommands

### DIFF
--- a/tools/rpi/hoymiles/__init__.py
+++ b/tools/rpi/hoymiles/__init__.py
@@ -183,6 +183,8 @@ class ResponseDecoder(ResponseDecoderFactory):
                 model_desc = "Firmware version / date"
             elif command.upper() == '02':
                 model_desc = "Inverter generic events log"
+            elif command.upper() == '05':
+                model_desc = "Inverter generic SystemConfigPara"
             elif command.upper() == '0B':
                 model_desc = "mirco-inverters status data"
             elif command.upper() == '0C':

--- a/tools/rpi/hoymiles/__init__.py
+++ b/tools/rpi/hoymiles/__init__.py
@@ -193,6 +193,8 @@ class ResponseDecoder(ResponseDecoderFactory):
                 model_desc = "Inverter generic events log"
             elif command.upper() == '12':
                 model_desc = "Inverter major events log"
+            else:
+                model_desc = "event not configured - check ahoy script"
             logging.info(f'model_decoder: {model}Decode{command.upper()} - {model_desc}')
 
         model_decoders = __import__('hoymiles.decoders')

--- a/tools/rpi/hoymiles/__main__.py
+++ b/tools/rpi/hoymiles/__main__.py
@@ -175,7 +175,7 @@ def poll_inverter(inverter, dtu_ser, do_init, retries):
     inv_str = str(inverter_ser)
     if do_init:
       command_queue[inv_str].append(hoymiles.compose_send_time_payload(InfoCommands.InverterDevInform_All))
-#      command_queue[inv_str].append(hoymiles.compose_send_time_payload(InfoCommands.SystemConfigPara))
+      command_queue[inv_str].append(hoymiles.compose_send_time_payload(InfoCommands.SystemConfigPara))
     command_queue[inv_str].append(hoymiles.compose_send_time_payload(InfoCommands.RealTimeRunData_Debug))
 
     # Put all queued commands for current inverter on air

--- a/tools/rpi/hoymiles/decoders/__init__.py
+++ b/tools/rpi/hoymiles/decoders/__init__.py
@@ -430,15 +430,15 @@ class DebugDecodeAny(UnknownResponse):
         l_payload = len(self.response)
         logging.debug(f' payload has {l_payload} bytes')
 
-        logging.debug()
+        logging.debug('')
         logging.debug('Field view: int')
         print_table_unpack('>B', self.response)
 
-        logging.debug()
+        logging.debug('')
         logging.debug('Field view: shorts')
         print_table_unpack('>H', self.response)
 
-        logging.debug()
+        logging.debug('')
         logging.debug('Field view: longs')
         print_table_unpack('>L', self.response)
 


### PR DESCRIPTION
Python goes in crash, when using an other InfoCommend
i.e. uncomment line 178 of __main__.py