### PR TITLE
improve display layout for Nokia5110

### DIFF
--- a/src/utils/helper.cpp
+++ b/src/utils/helper.cpp
@@ -50,6 +50,17 @@ namespace ah {
         return String(str);
     }
 
+    String getDateTimeStrShort(time_t t) {
+        char str[20];
+        if(0 == t)
+            sprintf(str, "n/a");
+        else {
+            sprintf(str, "%3s ", dayShortStr(dayOfWeek(t)));
+            sprintf(str+4, "%2d.%3s %02d:%02d", day(t), monthShortStr(month(t)), hour(t), minute(t));
+        }
+        return String(str);
+    }
+
     String getTimeStr(time_t t) {
         char str[9];
         if(0 == t)

--- a/src/utils/helper.h
+++ b/src/utils/helper.h
@@ -41,6 +41,7 @@ namespace ah {
     void ip2Char(uint8_t ip[], char *str);
     double round3(double value);
     String getDateTimeStr(time_t t);
+    String getDateTimeStrShort(time_t t);
     String getDateTimeStrFile(time_t t);
     String getTimeStr(time_t t);
     uint64_t Serial2u64(const char *val);


### PR DESCRIPTION
Ich habe mir in meinem Fork das Layout des Nokia Displays etwas zurecht gerückt. Im Unterschied zu vorher gibt es jetzt 5 Zeilen statt 4, wobei die Schriftgrößen gleich geblieben sind. Es waren nur die Zeilenoffsets nicht ganz korrekt berechnet. In der obersten Zeile steht jetzt dauerhaft das Datum und die Uhrzeit, was aus meiner Sicht einen kleinen Mehrwert darstellt für so ein Kästchen, das ohnehin die ganze Zeit im Vorzimmer steht. Die zweite Zeile ist die Statusanzeige für den/die Inverter, der ab und an auch noch die IP Adresse anzeigt. Hier möchte ich evt. noch den MQTT Status dazu anzeigen, für den normalerweise die Led1 vorgesehen ist. Außerdem habe ich die Zeilen noch zentriert, mir war die Anzeige etwas zu 'schieflastig'. 
Aussehen tut das Ganze so:
![Nokia](https://github.com/lumapu/ahoy/assets/6373072/cf2ff864-a4ef-4707-97dd-34605803213d)
Wenn's gefällt, bitte mergen!