### PR TITLE
Fix typos throughout code

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -172,7 +172,7 @@ class app : public IApp, public ah::Scheduler {
         }
 
         void ivSendHighPrio(Inverter<> *iv) {
-            if(mIVCommunicationOn) { // only send commands if communcation is enabled
+            if(mIVCommunicationOn) { // only send commands if communication is enabled
                 if (iv->ivGen == IV_HM)
                     mPayload.ivSendHighPrio(iv);
                 else if (iv->ivGen == IV_MI)

--- a/src/config/config_override_example.h
+++ b/src/config/config_override_example.h
@@ -9,11 +9,11 @@
 // override fallback WiFi info
 #define FB_WIFI_OVERRIDDEN
 
-// each ovveride must be preceeded with an #undef statement
+// each override must be preceded with an #undef statement
 #undef FB_WIFI_SSID
 #define FB_WIFI_SSID    "MY_SSID"
 
-// each ovveride must be preceeded with an #undef statement
+// each override must be preceded with an #undef statement
 #undef FB_WIFI_PWD
 #define FB_WIFI_PWD     "MY_WIFI_KEY"
 

--- a/src/hm/hmInverter.h
+++ b/src/hm/hmInverter.h
@@ -65,7 +65,7 @@ struct calcFunc_t {
 
 template<class T=float>
 struct record_t {
-    byteAssign_t* assign; // assigment of bytes in payload
+    byteAssign_t* assign; // assignment of bytes in payload
     uint8_t length;       // length of the assignment list
     T *record;            // data pointer
     uint32_t ts;          // timestamp of last received payload
@@ -151,7 +151,7 @@ class Inverter {
         InverterStatus status;           // indicates the current inverter status
         std::array<alarm_t, 10> lastAlarm; // holds last 10 alarms
         uint8_t       alarmNxtWrPos;     // indicates the position in array (rolling buffer)
-        uint16_t      alarmCnt;          // counts the total number of occured alarms
+        uint16_t      alarmCnt;          // counts the total number of occurred alarms
         int8_t        rssi;              // HMS and HMT inverters only
 
 
@@ -361,7 +361,7 @@ class Inverter {
                     //}
                 }
                 else
-                    DPRINTLN(DBG_WARN, F("add with unknown assginment"));
+                    DPRINTLN(DBG_WARN, F("add with unknown assignment"));
             }
             else
                 DPRINTLN(DBG_ERROR, F("addValue: assignment not found with cmd 0x"));

--- a/src/hm/hmRadio.h
+++ b/src/hm/hmRadio.h
@@ -231,7 +231,7 @@ class HmRadio {
 
         uint8_t getDataRate(void) {
             if(!mNrf24.isChipConnected())
-                return 3; // unkown
+                return 3; // unknown
             return mNrf24.getDataRate();
         }
 

--- a/src/hm/miPayload.h
+++ b/src/hm/miPayload.h
@@ -271,7 +271,7 @@ const byteAssign_t InfoAssignment[] = {
                 }
 
             } else if ( p->packet[0] == (TX_REQ_INFO + ALL_FRAMES) // response from get information command
-                     || (p->packet[0] == 0xB6 && mPayload[iv->id].txCmd != 0x36)) {                   // strange short response from MI-1500 3rd gen; might be missleading!
+                     || (p->packet[0] == 0xB6 && mPayload[iv->id].txCmd != 0x36)) {                   // strange short response from MI-1500 3rd gen; might be misleading!
                 // atm, we just do nothing else than print out what we got...
                 // for decoding see xls- Data collection instructions - #147ff
                 //mPayload[iv->id].txId = p->packet[0];
@@ -280,7 +280,7 @@ const byteAssign_t InfoAssignment[] = {
                 if (*pid == 0x00) {
                     DPRINT(DBG_DEBUG, F("fragment number zero received"));
                     iv->setQueuedCmdFinished();
-                } else if (p->packet[9] == 0x81) { // might need some additional check, as this is only ment for short answers!
+                } else if (p->packet[9] == 0x81) { // might need some additional check, as this is only meant for short answers!
                     DPRINT_IVID(DBG_WARN, iv->id);
                     DBGPRINTLN(F("seems to use 3rd gen. protocol - switching ivGen!"));
                     iv->ivGen = IV_HM;
@@ -404,7 +404,7 @@ const byteAssign_t InfoAssignment[] = {
                     (mPayload[iv->id].txId != (0x88)) &&
                     (mPayload[iv->id].txId != (0x92)) &&
                     (mPayload[iv->id].txId != 0 )) {
-                    // no processing needed if txId is not one of 0x95, 0x88, 0x89, 0x91, 0x92 or resonse to 0x36ff
+                    // no processing needed if txId is not one of 0x95, 0x88, 0x89, 0x91, 0x92 or response to 0x36ff
                     mPayload[iv->id].complete = true;
                     continue; // skip to next inverter
                 }

--- a/src/hms/cmt2300a.h
+++ b/src/hms/cmt2300a.h
@@ -8,7 +8,7 @@
 
 #include "esp32_3wSpi.h"
 
-#define WORK_FREQ_KHZ       865000 // disired work frequency between DTU and
+#define WORK_FREQ_KHZ       865000 // desired work frequency between DTU and
                                    // inverter in kHz
 #define HOY_BASE_FREQ_KHZ   860000 // in kHz
 #define HOY_MAX_FREQ_KHZ    923500 // 0xFE * 250kHz + Base_freq
@@ -153,7 +153,7 @@
 #define CMT2300A_MASK_TX_DONE_FLG       0x08
 #define CMT2300A_MASK_PKT_OK_FLG        0x01
 
-// default CMT paramters
+// default CMT parameters
 static uint8_t cmtConfig[0x60] PROGMEM {
     // 0x00 - 0x0f -- RSSI offset +- 0 and 13dBm
     0x00, 0x66, 0xEC, 0x1C, 0x70, 0x80, 0x14, 0x08,
@@ -360,7 +360,7 @@ class Cmt2300a {
 
         inline uint8_t freq2Chan(const uint32_t freqKhz) {
             if((freqKhz % FREQ_STEP_KHZ) != 0) {
-                DPRINT(DBG_WARN, F("swtich frequency to "));
+                DPRINT(DBG_WARN, F("switch frequency to "));
                 DBGPRINT(String(freqKhz));
                 DBGPRINT(F("kHz not possible!"));
                 return 0xff; // error
@@ -373,7 +373,7 @@ class Cmt2300a {
                 return 0xff; // error
 
             if((freqKhz < FREQ_WARN_MIN_KHZ) || (freqKhz > FREQ_WARN_MAX_KHZ))
-                DPRINTLN(DBG_WARN, F("Disired frequency is out of EU legal range! (863 - 870MHz)"));
+                DPRINTLN(DBG_WARN, F("Desired frequency is out of EU legal range! (863 - 870MHz)"));
 
             return (freqKhz - HOY_BASE_FREQ_KHZ) / FREQ_STEP_KHZ;
         }

--- a/src/plugins/Display/Display_ePaper.cpp
+++ b/src/plugins/Display/Display_ePaper.cpp
@@ -205,7 +205,7 @@ void DisplayEPaper::actualPowerPaged(float totalPower, float totalYieldDay, floa
 void DisplayEPaper::loop(float totalPower, float totalYieldDay, float totalYieldTotal, uint8_t isprod) {
     // check if the IP has changed
     if (_settedIP != WiFi.localIP().toString().c_str()) {
-        // save the new IP and call the Headline Funktion to adapt the Headline
+        // save the new IP and call the Headline Function to adapt the Headline
         _settedIP = WiFi.localIP().toString().c_str();
         headlineIP();
     }

--- a/src/publisher/pubMqtt.h
+++ b/src/publisher/pubMqtt.h
@@ -606,7 +606,7 @@ class PubMqtt {
         uint32_t mIvLastRTRpub[MAX_NUM_INVERTERS];
         uint16_t mIntervalTimeout;
 
-        // last will topic and payload must be available trough lifetime of 'espMqttClient'
+        // last will topic and payload must be available through lifetime of 'espMqttClient'
         char mLwtTopic[MQTT_TOPIC_LEN+5];
         const char *mDevName, *mVersion;
         char mClientId[24]; // number of chars is limited to 23 up to v3.1 of MQTT

--- a/src/utils/improv.h
+++ b/src/utils/improv.h
@@ -39,7 +39,7 @@ class Improv {
             if(!checkPaket(&buf[0], len, [this](uint8_t type, uint8_t buf[], uint8_t len) {
                 parsePayload(type, buf, len);
             })) {
-                DBGPRINTLN(F("check paket failed"));
+                DBGPRINTLN(F("check packet failed"));
             }
             dumpBuf(buf, len);
         }
@@ -100,7 +100,7 @@ class Improv {
             if(0 != strncmp((char*)buf, "IMPROV", 6))
                 return false;
 
-            // verison check (only version 1 is supported!)
+            // version check (only version 1 is supported!)
             if(0x01 != buf[6])
                 return false;
 
@@ -124,7 +124,7 @@ class Improv {
         void sendDevInfo(void) {
             uint8_t buf[50];
             buf[7] = TYPE_RPC_RESPONSE;
-            buf[9] = GET_DEVICE_INFO; // repsonse to cmd
+            buf[9] = GET_DEVICE_INFO; // response to cmd
             uint8_t p = 11;
             // firmware name
             p += char2Improv("AhoyDTU", &buf[p]);
@@ -140,7 +140,7 @@ class Improv {
             p += char2Improv(mDevName, &buf[p]);
 
             buf[10] = p - 11; // sub length
-            buf[8] = p - 9; // paket length
+            buf[8] = p - 9; // packet length
 
             sendPaket(buf, p);
         }
@@ -157,7 +157,7 @@ class Improv {
 
             uint8_t buf[50];
             buf[7] = TYPE_RPC_RESPONSE;
-            buf[9] = GET_WIFI_NETWORKS; // repsonse to cmd
+            buf[9] = GET_WIFI_NETWORKS; // response to cmd
             uint8_t p = 11;
 
             JsonArray arr = obj[F("networks")];
@@ -170,7 +170,7 @@ class Improv {
                 p += char2Improv(String(arr[i][F("rssi")]).c_str(), &buf[p]);
 
                 buf[10] = p - 11; // sub length
-                buf[8] = p - 9; // paket length
+                buf[8] = p - 9; // packet length
 
                 sendPaket(buf, p);
             }

--- a/src/web/RestApi.h
+++ b/src/web/RestApi.h
@@ -280,7 +280,7 @@ class RestApi {
             getGeneric(request, obj.createNestedObject(F("generic")));
             obj[F("refresh")] = 3;
             obj[F("refresh_url")] = "/";
-            obj[F("html")] = F("succesfully logged out");
+            obj[F("html")] = F("successfully logged out");
         }
 
         void getHtmlReboot(AsyncWebServerRequest *request, JsonObject obj) {

--- a/src/web/html/index.html
+++ b/src/web/html/index.html
@@ -47,7 +47,7 @@
             function apiCb(obj) {
                 var e = document.getElementById("apiResult");
                 if(obj["success"]) {
-                    e.innerHTML = " command excuted";
+                    e.innerHTML = " command executed";
                     getAjax("/api/index", parse);
                 }
                 else

--- a/src/web/html/setup.html
+++ b/src/web/html/setup.html
@@ -65,7 +65,7 @@
                                 <div class="col-12 col-sm-9"><input type="text" name="ap_pwd" minlength="8" /></div>
                             </div>
 
-                            <p>Enter the credentials to your prefered WiFi station. After rebooting the device tries to connect with this information.</p>
+                            <p>Enter the credentials to your preferred WiFi station. After rebooting the device tries to connect with this information.</p>
 
                             <div class="row mb-3">
                                 <div class="col-12 col-sm-3 my-2">Search Networks</div>
@@ -181,7 +181,7 @@
                             <div class="col-4 col-sm-9"><input type="checkbox" name="strtWthtTm"/></div>
                         </div>
                         <div class="row mb-3">
-                            <div class="col-8 col-sm-3">Yield Effiency (should be between 0.95 and 0.96)</div>
+                            <div class="col-8 col-sm-3">Yield Efficiency (should be between 0.95 and 0.96)</div>
                             <div class="col-4 col-sm-9"><input type="number" name="yldEff" step="any"/></div>
                         </div>
                     </fieldset>
@@ -200,7 +200,7 @@
                             <div class="col-12 col-sm-9"><input type="number" name="ntpPort"/></div>
                         </div>
                         <div class="row mb-3">
-                            <div class="col-12 col-sm-3 my-2">NTP Intervall (in Minutes, min. 5 Minutes)</div>
+                            <div class="col-12 col-sm-3 my-2">NTP Interval (in Minutes, min. 5 Minutes)</div>
                             <div class="col-12 col-sm-9"><input type="number" name="ntpIntvl"/></div>
                         </div>
                         <div class="row mb-3">
@@ -487,7 +487,7 @@
             function apiCbNtp(obj) {
                 var e = document.getElementById("apiResultNtp");
                 if(obj["success"])
-                    e.innerHTML = "command excuted, set new time ...";
+                    e.innerHTML = "command executed, set new time ...";
                 else
                     e.innerHTML = "Error: " + obj["error"];
             }
@@ -501,7 +501,7 @@
             function apiCbMqtt(obj) {
                 var e = document.getElementById("apiResultMqtt");
                 if(obj["success"])
-                    e.innerHTML = "command excuted";
+                    e.innerHTML = "command executed";
                 else
                     e.innerHTML = "Error: " + obj["error"];
             }

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -666,7 +666,7 @@ class Web {
 #ifdef ENABLE_PROMETHEUS_EP
         // Note
         // Prometheus exposition format is defined here: https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md
-        // TODO: Check packetsize for MAX_NUM_INVERTERS. Successfull Tested with 4 Inverters (each with 4 channels)
+        // TODO: Check packetsize for MAX_NUM_INVERTERS. Successfully Tested with 4 Inverters (each with 4 channels)
         enum {
             metricsStateStart,
             metricsStateInverter1, metricsStateInverter2, metricsStateInverter3, metricsStateInverter4,


### PR DESCRIPTION
Found with `codespell -w -i3 src/**` and reviewed manually.

Fixes: #1112