### PR TITLE
Refactor WifiConncetion code to work with ESP32-S2

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -225,9 +225,9 @@ void app::onNetwork(bool gotIp) {
         #if !defined(ETHERNET)
         if (WIFI_AP == WiFi.getMode()) {
             mMqttEnabled = false;
-            everySec(std::bind(&ahoywifi::tickWifiLoop, &mWifi), "wifiL");
         }
-        #endif /* !defined(ETHERNET) */
+        everySec(std::bind(&ahoywifi::tickWifiLoop, &mWifi), "wifiL");
+#endif /* !defined(ETHERNET) */
         mInnerLoopCb = [this]() { this->loopStandard(); };
     } else {
         #if defined(ETHERNET)

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -56,6 +56,17 @@
 
 // default pinout (GPIO Number)
 #if defined(ESP32)
+#if defined(CONFIG_IDF_TARGET_ESP32S2)
+    // Layout for the ESP32-S2 mini from LOLIN.
+    // The pins are all lined up on the outer side of the board
+    // We will use HSPI
+    #define DEF_CS_PIN              12
+    #define DEF_CE_PIN              3
+    #define DEF_IRQ_PIN             5
+    #define DEF_MISO_PIN            9
+    #define DEF_MOSI_PIN            11
+    #define DEF_SCLK_PIN            7
+#else
     // this is the default ESP32 (son-S) pinout on the WROOM modules for VSPI,
     // for the ESP32-S3 there is no sane 'default', as it has full flexibility
     // to map its two HW SPIs anywhere and PCBs differ materially,
@@ -66,6 +77,7 @@
     #define DEF_MISO_PIN            19
     #define DEF_MOSI_PIN            23
     #define DEF_SCLK_PIN            18
+#endif
 #else
     #define DEF_CS_PIN              15
     #define DEF_CE_PIN              0

--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -149,7 +149,6 @@ monitor_filters =
     time      ; Add timestamp with milliseconds for each new line
     log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
 
-
 [env:esp32-wroom32-ethernet-release]
 platform = espressif32
 board = esp32dev
@@ -172,6 +171,36 @@ build_flags =
 build_unflags = -std=gnu++11
 monitor_filters =
     esp32_exception_decoder
+
+[env:esp-32-s2-mini-release]
+platform = espressif32@6.3.2
+board = lolin_s2_mini
+build_flags =
+    -D RELEASE
+    -std=gnu++17
+
+build_unflags = -std=gnu++11
+monitor_filters =
+    esp32_exception_decoder
+
+[env:esp-32-s2-mini-debug]
+platform = espressif32@6.3.2
+board = lolin_s2_mini
+build_flags =
+    -DDEBUG_LEVEL=DBG_DEBUG
+    -DDEBUG_ESP_CORE
+    -DDEBUG_ESP_WIFI
+    -DDEBUG_ESP_HTTP_CLIENT
+    -DDEBUG_ESP_HTTP_SERVER
+    -DDEBUG_ESP_OOM
+    -DDEBUG_ESP_PORT=Serial
+    -std=gnu++17
+build_unflags = -std=gnu++11
+build_type = debug
+monitor_filters =
+    time      ; Add timestamp with milliseconds for each new line
+    log2file  ; Log data to a file “platformio-device-monitor-*.log” located in the current working directory
+
 
 [env:opendtufusionv1-release]
 platform = espressif32@6.1.0

--- a/src/wifi/ahoywifi.h
+++ b/src/wifi/ahoywifi.h
@@ -32,10 +32,13 @@ class ahoywifi {
     private:
         typedef enum WiFiStatus {
             DISCONNECTED = 0,
+            SCAN_READY,
             CONNECTING,
             CONNECTED,
             IN_AP_MODE,
-            GOT_IP
+            GOT_IP,
+            IN_STA_MODE,
+            RESET
         } WiFiStatus_t;
 
         void setupWifi(bool startAP);
@@ -43,9 +46,11 @@ class ahoywifi {
         void setupStation(void);
         void sendNTPpacket(IPAddress& address);
         void sortRSSI(int *sort, int n);
-        void getBSSIDs(void);
+        bool getBSSIDs(void);
         void connectionEvent(WiFiStatus_t status);
-        #if defined(ESP8266)
+        bool isTimeout(uint8_t timeout) {  return (mCnt % timeout) == 0; }
+
+#if defined(ESP8266)
         void onConnect(const WiFiEventStationModeConnected& event);
         void onGotIP(const WiFiEventStationModeGotIP& event);
         void onDisconnect(const WiFiEventStationModeDisconnected& event);
@@ -71,6 +76,7 @@ class ahoywifi {
 
         uint8_t mScanCnt;
         bool mScanActive;
+        bool mGotDisconnect;
         std::list<uint8_t> mBSSIDList;
 };
 


### PR DESCRIPTION
This pull request comes with a refactored `tickWifiLoop()`.
It failed to work on an ESP32-S2 due to threading issues. All the event are executred in a separate thread which lead to problems with the current design.
I re-worked the logic to be better visible and especially to ensure that all complex calls are made in the main thread and not during event handling.
Also call the` tickWifiLoop()` function even when fully connected, to be able to detect disconnects. This is necessary since I wanted to avoid calls from the event handler thread to the `app`.
Why the old code only failed on the S2 is not clear to me, I can just assume that either the framework is slightly different or it's sheer luck that the different timing of the older chips worked better.


Does work with ESP32-S2 now.
Has been tested with **_ESP32-S2_** and **_ESP32 WROOM_**.

Did not test the following:

- ESP8266 (should work as well)
- Use cases
--  After connection to a network no IP-Address is received.
--  Disconnection from Network after being fully connected. (Only partially tested)