### PR TITLE
Prometheus Endpoint: Use default channel name if non is set. Export inverter metrics as <XX>_total metric if channel metrics also available.

### DIFF
--- a/doc/prometheus_ep_description.md
+++ b/doc/prometheus_ep_description.md
@@ -15,37 +15,40 @@ Prometheus metrics provided at `/metrics`.
 | channel      | Channel (Module) name from setup. Label only available if max power level of module is set to non-zero. Be sure to have a cannel name set in configuration. |
 
 ## Exported Metrics
-| Metric name                            | Type    | Description                                            | Labels       | 
-|----------------------------------------|---------|--------------------------------------------------------|--------------|
-| `ahoy_solar_info`                      | Gauge   | Information about the AhoyDTU device                   | version, image, devicename |
-| `ahoy_solar_uptime`                    | Counter | Seconds since boot of the AhoyDTU device               | devicename |
-| `ahoy_solar_rssi_db`                   | Gauge   | Quality of the Wifi STA connection                     | devicename |
-| `ahoy_solar_inverter_info`             | Gauge   | Information about the configured inverter(s)           | name, serial |
-| `ahoy_solar_inverter_enabled`          | Gauge   | Is the inverter enabled?                               | inverter  |
-| `ahoy_solar_inverter_is_available`     | Gauge   | is the inverter available?                             | inverter  |
-| `ahoy_solar_inverter_is_producing`     | Gauge   | Is the inverter producing?                             | inverter  |
-| `ahoy_solar_U_AC_volt`                 | Gauge   | AC voltage of inverter [V]                             | inverter  | 
-| `ahoy_solar_I_AC_ampere`               | Gauge   | AC current of inverter [A]                             | inverter  | 
-| `ahoy_solar_P_AC_watt`                 | Gauge   | AC power of inverter [W]                               | inverter  | 
-| `ahoy_solar_Q_AC_var`                  | Gauge   | AC reactive power[var]                                 | inverter  | 
-| `ahoy_solar_F_AC_hertz`                | Gauge   | AC frequency [Hz]                                      | inverter  | 
-| `ahoy_solar_PF_AC`                     | Gauge   | AC Power factor                                        | inverter  | 
-| `ahoy_solar_Temp_celsius`              | Gauge   | Temperature of inverter                                | inverter  | 
-| `ahoy_solar_ALARM_MES_ID`              | Gauge   | Alarm message index of inverter                        | inverter  | 
-| `ahoy_solar_LastAlarmCode`             | Gauge   | Last alarm code from inverter                          | inverter  | 
-| `ahoy_solar_YieldDay_wattHours`        | Counter | Energy converted to AC per day [Wh]                    | inverter  | 
-| `ahoy_solar_YieldTotal_kilowattHours`  | Counter | Energy converted to AC since reset [kWh]               | inverter  | 
-| `ahoy_solar_P_DC_watt`                 | Gauge   | DC power of inverter [W]                               | inverter  | 
-| `ahoy_solar_Efficiency_ratio`          | Gauge   | ration AC Power over DC Power [%]                      | inverter  | 
-| `ahoy_solar_U_DC_volt`                 | Gauge   | DC voltage of channel [V]                              | inverter, channel | 
-| `ahoy_solar_I_DC_ampere`               | Gauge   | DC current of channel [A]                              | inverter, channel | 
-| `ahoy_solar_P_DC_watt`                 | Gauge   | DC power of channel [P]                                | inverter, channel | 
-| `ahoy_solar_YieldDay_wattHours`        | Counter | Energy converted to AC per day [Wh]                    | inverter, channel | 
-| `ahoy_solar_YieldTotal_kilowattHours`  | Counter | Energy converted to AC since reset [kWh]               | inverter, channel | 
-| `ahoy_solar_Irradiation_ratio`         | Gauge   | ratio DC Power over set maximum power per channel [%]  | inverter, channel |
-| `ahoy_solar_radio_rx_success`          | Gauge   | NRF24 statistic                                        | |
-| `ahoy_solar_radio_rx_fail`             | Gauge   | NRF24 statistic                                        | |
-| `ahoy_solar_radio_rx_fail_answer`      | Gauge   | NRF24 statistic                                        | |
-| `ahoy_solar_radio_frame_cnt`           | Gauge   | NRF24 statistic                                        | |
-| `ahoy_solar_radio_tx_cnt`              | Gauge   | NRF24 statistic                                        | |
+| Metric name                                  | Type    | Description                                              | Labels       |
+|----------------------------------------------|---------|----------------------------------------------------------|--------------|
+| `ahoy_solar_info`                            | Gauge   | Information about the AhoyDTU device                     | version, image, devicename |
+| `ahoy_solar_uptime`                          | Counter | Seconds since boot of the AhoyDTU device                 | devicename |
+| `ahoy_solar_rssi_db`                         | Gauge   | Quality of the Wifi STA connection                       | devicename |
+| `ahoy_solar_inverter_info`                   | Gauge   | Information about the configured inverter(s)             | name, serial |
+| `ahoy_solar_inverter_enabled`                | Gauge   | Is the inverter enabled?                                 | inverter  |
+| `ahoy_solar_inverter_is_available`           | Gauge   | is the inverter available?                               | inverter  |
+| `ahoy_solar_inverter_is_producing`           | Gauge   | Is the inverter producing?                               | inverter  |
+| `ahoy_solar_U_AC_volt`                       | Gauge   | AC voltage of inverter [V]                               | inverter  |
+| `ahoy_solar_I_AC_ampere`                     | Gauge   | AC current of inverter [A]                               | inverter  |
+| `ahoy_solar_P_AC_watt`                       | Gauge   | AC power of inverter [W]                                 | inverter  |
+| `ahoy_solar_Q_AC_var`                        | Gauge   | AC reactive power[var]                                   | inverter  |
+| `ahoy_solar_F_AC_hertz`                      | Gauge   | AC frequency [Hz]                                        | inverter  |
+| `ahoy_solar_PF_AC`                           | Gauge   | AC Power factor                                          | inverter  |
+| `ahoy_solar_Temp_celsius`                    | Gauge   | Temperature of inverter                                  | inverter  |
+| `ahoy_solar_ALARM_MES_ID`                    | Gauge   | Alarm message index of inverter                          | inverter  |
+| `ahoy_solar_LastAlarmCode`                   | Gauge   | Last alarm code from inverter                            | inverter  |
+| `ahoy_solar_YieldDay_wattHours`              | Counter | Energy converted to AC per day [Wh]                      | inverter,channel  |
+| `ahoy_solar_YieldDay_wattHours_total`        | Counter | Energy converted to AC per day [Wh] for all moduls       | inverter  |
+| `ahoy_solar_YieldTotal_kilowattHours`        | Counter | Energy converted to AC since reset [kWh]                 | inverter,channel  |
+| `ahoy_solar_YieldTotal_kilowattHours_total`  | Counter | Energy converted to AC since reset [kWh] for all modules | inverter  |
+| `ahoy_solar_P_DC_watt`                       | Gauge   | DC power of inverter [W]                                 | inverter  |
+| `ahoy_solar_Efficiency_ratio`                | Gauge   | ration AC Power over DC Power [%]                        | inverter  |
+| `ahoy_solar_U_DC_volt`                       | Gauge   | DC voltage of channel [V]                                | inverter, channel |
+| `ahoy_solar_I_DC_ampere`                     | Gauge   | DC current of channel [A]                                | inverter, channel |
+| `ahoy_solar_P_DC_watt`                       | Gauge   | DC power of channel [P]                                  | inverter, channel |
+| `ahoy_solar_P_DC_watt_total`                 | Gauge   | DC power of inverter [P]                                 | inverter |
+| `ahoy_solar_YieldDay_wattHours`              | Counter | Energy converted to AC per day [Wh]                      | inverter, channel |
+| `ahoy_solar_YieldTotal_kilowattHours`        | Counter | Energy converted to AC since reset [kWh]                 | inverter, channel |
+| `ahoy_solar_Irradiation_ratio`               | Gauge   | ratio DC Power over set maximum power per channel [%]    | inverter, channel |
+| `ahoy_solar_radio_rx_success`                | Gauge   | NRF24 statistic                                          | |
+| `ahoy_solar_radio_rx_fail`                   | Gauge   | NRF24 statistic                                          | |
+| `ahoy_solar_radio_rx_fail_answer`            | Gauge   | NRF24 statistic                                          | |
+| `ahoy_solar_radio_frame_cnt`                 | Gauge   | NRF24 statistic                                          | |
+| `ahoy_solar_radio_tx_cnt`                    | Gauge   | NRF24 statistic                                          | |
 

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -800,16 +800,31 @@ class Web {
                                             // This is the correct field to report
                                             std::tie(promUnit, promType) = convertToPromUnits(iv->getUnit(metricsChannelId, rec));
                                             // Declare metric only once
-                                            if (!metricDeclared) {
+                                            if (channel != 0 && !metricDeclared) {
                                                 snprintf(type, sizeof(type), "# TYPE ahoy_solar_%s%s %s\n", iv->getFieldName(metricsChannelId, rec), promUnit.c_str(), promType.c_str());
                                                 metrics += type;
                                                 metricDeclared = true;
                                             }
                                             // report value
                                             if (0 == channel) {
-                                                snprintf(topic, sizeof(topic), "ahoy_solar_%s%s{inverter=\"%s\"}", iv->getFieldName(metricsChannelId, rec), promUnit.c_str(), iv->config->name);
+                                                char total[7];
+                                                total[0] = 0;
+                                                if (metricDeclared) {
+                                                    // A declaration and value for channels has been delivered. So declare and deliver a _total metric
+                                                    strncpy(total,"_total",sizeof(total));
+                                                }
+                                                snprintf(type, sizeof(type), "# TYPE ahoy_solar_%s%s%s %s\n", iv->getFieldName(metricsChannelId, rec), promUnit.c_str(), total, promType.c_str());
+                                                metrics += type;
+                                                snprintf(topic, sizeof(topic), "ahoy_solar_%s%s%s{inverter=\"%s\"}", iv->getFieldName(metricsChannelId, rec), promUnit.c_str(), total,iv->config->name);
                                             } else {
-                                                snprintf(topic, sizeof(topic), "ahoy_solar_%s%s{inverter=\"%s\",channel=\"%s\"}", iv->getFieldName(metricsChannelId, rec), promUnit.c_str(), iv->config->name,iv->config->chName[channel-1]);
+                                                // Use a fallback channel name (ch0, ch1, ...)if non is given by user
+                                                char chName[MAX_NAME_LENGTH];
+                                                if (iv->config->chName[channel-1][0] != 0) {
+                                                    strncpy(chName, iv->config->chName[channel-1], sizeof(chName));
+                                                } else {
+                                                    snprintf(chName,sizeof(chName),"ch%1d",channel);
+                                                }
+                                                snprintf(topic, sizeof(topic), "ahoy_solar_%s%s{inverter=\"%s\",channel=\"%s\"}", iv->getFieldName(metricsChannelId, rec), promUnit.c_str(), iv->config->name,chName);
                                             }
                                             snprintf(val, sizeof(val), " %.3f\n", iv->getValue(metricsChannelId, rec));
                                             metrics += topic;


### PR DESCRIPTION
Angeregt durch eine weitere Diskussion über #853 habe ich den Prometheus EP etwas angepasst.

- Es wird nun ein Channel Name generiert (ch0, ch1) falls der Channel aktiv ist aber keinen Namen hat.
- Die aufsummierten Invertermetriken für `ahoy_solar_P_DC_watt`, `ahoy_solar_YieldTotal_kilowattHours` und `ahoy_solar_YieldDay_wattHours` erhalten das suffix `_total`

Wenn's gefällt bitte übernehmen.
