### PR TITLE
Remove obsolete #define MIDNIGHTTICKER_OFFSET

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -208,13 +208,6 @@
 // reconnect delay
 #define MQTT_RECONNECT_DELAY    5000
 
-// Offset for midnight Ticker
-// relative to UTC
-//   may be negative for later in the next day or positive for earlier in previous day
-//   may contain variable like mCalculatedTimezoneOffset
-// must be in parentheses
-#define MIDNIGHTTICKER_OFFSET (-1)
-
 #if __has_include("config_override.h")
     #include "config_override.h"
 #endif

--- a/src/config/config_override_example.h
+++ b/src/config/config_override_example.h
@@ -31,10 +31,6 @@
 #undef DEF_SCLK_PIN
 #define DEF_SCLK_PIN 36
 
-// Offset for midnight Ticker Example: 1 second before midnight (local time)
-#undef MIDNIGHTTICKER_OFFSET
-#define MIDNIGHTTICKER_OFFSET (mCalculatedTimezoneOffset + 1)
-
 // To enable the endpoint for prometheus to scrape data from at /metrics
 // #define ENABLE_PROMETHEUS_EP
 


### PR DESCRIPTION
Kleine Altlastenbeseitigung

Das Symbol MIDNIGHTTICKER_OFFSET wurde  mit PR #698 eingefügt welcher kurze Zeit später durch eine automatische Lösung ersetzt wurde. Allerdings ist das Symbol MIDNIGHTTICKER_OFFSET in den config headern übrig gebieben.
Dieser PR beseitigt das Symbol