### PR TITLE
fix: web setup.html: textfield max name length of INVERTER name

### DIFF
--- a/src/web/html/setup.html
+++ b/src/web/html/setup.html
@@ -632,7 +632,7 @@
                     })
                 });
 
-                iv.append(mlE("Name*", inp(id + "Name", obj["name"], 16, ["text"], null, "text", "[\\-\\+A-Za-z0-9.\\/#$%&=_]+", "Invalid input")));
+                iv.append(mlE("Name*", inp(id + "Name", obj["name"], 15, ["text"], null, "text", "[\\-\\+A-Za-z0-9.\\/#$%&=_]+", "Invalid input")));
 
                 for(var j of [
                     ["ModPwr", "ch_max_pwr", "Max Module Power (Wp)", 4, "[0-9]+"],


### PR DESCRIPTION
off-by-one name length flaw: entering 16 chars for inverter. name would be 15 chars (cut) long after SAVE and reboot

(falls der INVERTERNAME wirklich nicht länger sein soll als 15 Zeichen in der persistence, dann fix natürlich woanders )