### PR TITLE
build hm mipayload warning

### DIFF
--- a/src/hm/miPayload.h
+++ b/src/hm/miPayload.h
@@ -478,7 +478,7 @@ class MiPayload {
             if ( statusMi != mPayload[iv->id].sts[stschan] ) { //sth.'s changed?
                 iv->alarmCnt = 1; // minimum...
                 if (iv->type != INV_TYPE_1CH && ( statusMi != 3 //sth is or was wrong!
-                                                || mPayload[iv->id].sts[stschan] && statusMi == 3 && mPayload[iv->id].sts[stschan] != 3)
+                                                || ( mPayload[iv->id].sts[stschan] && statusMi == 3 && mPayload[iv->id].sts[stschan] != 3) )
                    ) {
                     iv->lastAlarm[stschan] = alarm_t(prntsts, mPayload[iv->id].ts,mPayload[iv->id].ts);
                     iv->alarmCnt = iv->type == INV_TYPE_2CH ? 3 : 5;


### PR DESCRIPTION
add to alarm list :
if laststatus was not 3
if laststatus was 3 and currentstatus is 3

add to better reading?
currentStatusMi = mPayload[iv->id].sts[stschan];


WiP

In file included from app.h:21,
                 from app.cpp:8:
hm/miPayload.h: In instantiation of 'void MiPayload<HMSYSTEM, HMRADIO>::miStsConsolidate(Inverter<>*, uint8_t, record_t<>*, uint8_t, uint8_t, uint8_t, uint8_t) [with HMSYSTEM = HmSystem<4>; HMRADIO = HmRadio<>; uint8_t = unsigned char]':
hm/miPayload.h:451:13:   required from 'void MiPayload<HMSYSTEM, HMRADIO>::miStsDecode(Inverter<>*, packet_t*, uint8_t) [with HMSYSTEM = HmSystem<4>; HMRADIO = HmRadio<>; uint8_t = unsigned char]'
hm/miPayload.h:175:17:   required from 'void MiPayload<HMSYSTEM, HMRADIO>::add(Inverter<>*, packet_t*) [with HMSYSTEM = HmSystem<4>; HMRADIO = HmRadio<>]'
app.cpp:143:41:   required from here
hm/miPayload.h:481:99: warning: suggest parentheses around '&&' within '||' [-Wparentheses]
  481 |                                                 || mPayload[iv->id].sts[stschan] && statusMi == 3 && mPayload[iv->id].sts[stschan] != 3)