### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/hm/hmInverter.h
+++ b/src/hm/hmInverter.h
@@ -88,7 +88,7 @@ class CommandAbstract {
         };
         virtual ~CommandAbstract() {};
 
-        const uint8_t getCmd() {
+        uint8_t getCmd() const {
             return _Cmd;
         }
 

--- a/src/hms/hmsPayload.h
+++ b/src/hms/hmsPayload.h
@@ -324,7 +324,6 @@ class HmsPayload {
 
                             if(AlarmData == mPayload[iv->id].txCmd) {
                                 uint8_t i = 0;
-                                uint32_t start, end;
                                 while(1) {
                                     if(0 == iv->parseAlarmLog(i++, payload, payloadLen))
                                         break;

--- a/src/utils/dbg.h
+++ b/src/utils/dbg.h
@@ -148,7 +148,7 @@
     #define PVERBLN(str)
 #endif
 
-#define DPRINT(level, str) ({\
+#define DPRINT(level, str) do {\
     switch(level) {\
         case DBG_ERROR: PERR(str);  break; \
         case DBG_WARN:  PWARN(str); break; \
@@ -156,13 +156,13 @@
         case DBG_DEBUG: PDBG(str);  break; \
         default:        PVERB(str); break; \
     }\
-})
+} while (0)
 
-#define DPRINT_IVID(level, id) ({\
+#define DPRINT_IVID(level, id) do {\
     DPRINT(level, F("(#")); DBGPRINT(String(id)); DBGPRINT(F(") "));\
-})
+} while (0)
 
-#define DPRINTLN(level, str) ({\
+#define DPRINTLN(level, str) do {\
     switch(level) {\
         case DBG_ERROR: PERRLN(str);  break; \
         case DBG_WARN:  PWARNLN(str); break; \
@@ -170,7 +170,7 @@
         case DBG_DEBUG: PDBGLN(str);  break; \
         default:        PVERBLN(str); break; \
     }\
-})
+} while (0)
 
 
 /*class ahoyLog {

--- a/src/utils/helper.h
+++ b/src/utils/helper.h
@@ -20,21 +20,21 @@ static Timezone gTimezone(CEST, CET);
 
 #define CHECK_MASK(a,b) ((a & b) == b)
 
-#define CP_U32_LittleEndian(buf, v) ({ \
+#define CP_U32_LittleEndian(buf, v) do { \
     uint8_t *b = buf; \
     b[0] = ((v >> 24) & 0xff); \
     b[1] = ((v >> 16) & 0xff); \
     b[2] = ((v >>  8) & 0xff); \
     b[3] = ((v      ) & 0xff); \
-})
+} while (0)
 
-#define CP_U32_BigEndian(buf, v) ({ \
+#define CP_U32_BigEndian(buf, v) do { \
     uint8_t *b = buf; \
     b[3] = ((v >> 24) & 0xff); \
     b[2] = ((v >> 16) & 0xff); \
     b[1] = ((v >>  8) & 0xff); \
     b[0] = ((v      ) & 0xff); \
-})
+} while (0)
 
 namespace ah {
     void ip2Arr(uint8_t ip[], const char *ipStr);

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -183,8 +183,8 @@ class Web {
             mUploadFp.write(data, len);
             if (final) {
                 mUploadFp.close();
-                char pwd[PWD_LEN];
                 #if !defined(ETHERNET)
+                char pwd[PWD_LEN];
                 strncpy(pwd, mConfig->sys.stationPwd, PWD_LEN); // backup WiFi PWD
                 #endif
                 if (!mApp->readSettings("/tmp.json")) {


### PR DESCRIPTION
When building with `-Wall` or `-Wextra` more warnings appear.  Some are easy to fix.  See commit messages of particular changesets for details.