### PR TITLE
fix null pointer access in display.h

### DIFF
--- a/src/plugins/Display/Display.h
+++ b/src/plugins/Display/Display.h
@@ -91,11 +91,13 @@ class Display {
         Inverter<> *iv;
         record_t<> *rec;
         bool allOff = true;
-        for (uint8_t i = 0; i < mSys->getNumInverters(); i++) {
+        uint8_t nInv = mSys->getNumInverters();
+        for (uint8_t i = 0; i < nInv; i++) {
             iv = mSys->getInverterByPos(i);
-            rec = iv->getRecordStruct(RealTimeRunData_Debug);
             if (iv == NULL)
                 continue;
+
+            rec = iv->getRecordStruct(RealTimeRunData_Debug);
 
             if (iv->isProducing())
                 nrprod++;


### PR DESCRIPTION
Kleiner bugfix: Zugriff auf getRecordStruct() mit null-pointer. Aufgrund der 'Harmlosigkeit' der getRecordStruct()  Methode dürfte es in der Praxis bisher keine Auswirkung gehabt haben, sollte jedoch dennoch behoben werden.

Bei der Gelegenheit habe ich auch getNumInverters() aus der for-Schleife herausgehoben. Diese Funktion war ja ursprünglich scheinbar selbst als Suchschleife implementiert (Code ist noch auskommentiert vorhanden), und so etwas könnte schon unnötigerweise etwas Zeit verbraten.

PS: Dass getNumInverters() nun immer die maximal mögliche Anzahl von Invertern liefert und nicht z.B. die tatsächlich Anzahl konfigurierter Inverter verstehe ich übrigens auch nicht. Das hat bei einer meiner kleinen Erweiterungen schon mal eine massive 'Guru Meditation' bewirkt ... Bleibt das so, oder ist das auch noch irgendein Workaround?