### PR TITLE
fix heutistics for MI type inverters

### DIFF
--- a/src/hm/Heuristic.h
+++ b/src/hm/Heuristic.h
@@ -48,8 +48,8 @@ class Heuristic {
         }
 
         void printStatus(Inverter<> *iv) {
-            DPRINT(DBG_INFO, F("Status:"));
-            DBGPRINT(F(" |"));
+            DPRINT_IVID(DBG_INFO, iv->id);
+            DBGPRINT(F("CH qualities:"));
             for(uint8_t i = 0; i < RF_MAX_CHANNEL_ID; i++) {
                 DBGPRINT(F(" "));
                 DBGPRINT(String(iv->txRfQuality[i]));


### PR DESCRIPTION
+ non working version of "firstTry" logic (?)

0.8.3 seemed to still have problems with retransmissions in case of missing answers to single packet requests; this also affects the "firstTry" part.