### PR TITLE
fix Inverter.isAvailable()

### DIFF
--- a/src/hm/hmInverter.h
+++ b/src/hm/hmInverter.h
@@ -391,6 +391,10 @@ class Inverter {
 
         bool isAvailable() {
             bool avail = false;
+
+            if (!((recordMeas.ts > 0) || (recordInfo.ts > 0) || (recordConfig.ts > 0) || (recordAlarm.ts > 0)))
+                return avail;
+
             if((*timestamp - recordMeas.ts) < INVERTER_INACT_THRES_SEC)
                 avail = true;
             if((*timestamp - recordInfo.ts) < INVERTER_INACT_THRES_SEC)


### PR DESCRIPTION
Keiner Bugfix: Inverter.isAvailable() lieferte beim Hochlauf true, und setzte den Inverter status schon in den STARTING Zustand obwohl noch keine Pakete vom Inverter empfangen wurden.