### PR TITLE
Little heuristic fix

### DIFF
--- a/src/hm/Heuristic.h
+++ b/src/hm/Heuristic.h
@@ -68,6 +68,8 @@ class Heuristic {
                 updateQuality(iv, -2); // BAD
                 mTestEn = true;
             }
+            else
+                mTestEn = false;
         }
 
         void printStatus(Inverter<> *iv) {


### PR DESCRIPTION
Nicht, dass ich die Kommunikations- Softwaremodule schon bis ins letzte Detail verstanden hätte, aber ich denke, ich habe da einen kleinen Bug in der Heuristik gefunden, der bei mir dazu geführt hat, dass die Heuristik bei sehr schlechter Verbindung (wenn ich z.B. absichtlich die Antenne abgezogen habe), prinzipiell im Testmodus geblieben ist, und gar nicht mehr zum ursprünglichen "best channel" gefunden hat. Damit ist der "best-channel" auch weiterhin immer gut geblieben, obwohl dieser natürlich auch nicht mehr richtig gefunkt hat, und der Radio-Balken am Display ist hoch geblieben, obwohl nichts mehr gegangen ist.....

Der Fix löst sicherlich nicht alle Kommunikationsprobleme, aber ich habe das Gefühl, dass mit dem Fix die Heuristik bei mir durchaus wieder etwas stabiler läuft. Bitte aber noch mal um Prüfung, ob ich da keinen Denkfehler habe.

Noch ein Hinweis zu einer zweiten Sache, die mir im Heuristik Code aufgefallen ist, und die ich noch nicht verstehe: 
Die Variablen mTestEn, mTestIdx und mStoredIdx gibt es für alle Inverter nur einmal gemeinsam ("global" in der Heuristik-Klasse). Mir erschiene es aber plausibler, wenn diese Variablen ebenfalls pro Inverter gemanaged würden, denn es kann ja durchaus sein, dass einer der Inverter gerade nicht optimal kommuniziert, und daher über den Testmode ein neuer Kanal ausprobiert werden soll, wovon aber die anderen Kanälen, die auf einem 'guten' Kanal verbunden sind, nicht betroffen sein sollen. Ich kann hier selbst leider aber keine Versuche dazu machen, da ich nur einen einzigen Inverter habe.


