### PR TITLE
Enhancement: mDNS Support in WiFi AP-Mode

### DIFF
--- a/src/wifi/ahoywifi.cpp
+++ b/src/wifi/ahoywifi.cpp
@@ -9,6 +9,7 @@
   #define F(sl) (sl)
 #endif
 #include "ahoywifi.h"
+#include <ESP8266mDNS.h>
 
 // NTP CONFIG
 #define NTP_PACKET_SIZE     48
@@ -83,6 +84,7 @@ void ahoywifi::tickWifiLoop() {
             if (mGotDisconnect) {
                 mStaConn = RESET;
             }
+            MDNS.update();
             return;
         case IN_AP_MODE:
             if (WiFi.softAPgetStationNum() == 0) {
@@ -180,6 +182,15 @@ void ahoywifi::tickWifiLoop() {
             mAppWifiCb(true);
             mGotDisconnect = false;
             mStaConn = IN_STA_MODE;
+
+            if (!MDNS.begin(mConfig->sys.deviceName)) {
+                DPRINTLN(DBG_ERROR, F("Error setting up MDNS responder!"));
+            } else {
+                DBGPRINT(F("[WiFi] mDNS established: "));
+                DBGPRINT(mConfig->sys.deviceName);
+                DBGPRINTLN(F(".local"));
+            }
+
             break;
         case RESET:
             mGotDisconnect = false;
@@ -244,7 +255,6 @@ void ahoywifi::setupStation(void) {
     if(String(mConfig->sys.deviceName) != "")
         WiFi.hostname(mConfig->sys.deviceName);
     WiFi.mode(WIFI_AP_STA);
-
 
     DBGPRINT(F("connect to network '"));
     DBGPRINT(mConfig->sys.stationSsid);


### PR DESCRIPTION
Unterstützung der Namensauflösung über mDNS wenn im WLan registriert.

Zugriff im Browser durch `http://ahoy-dtu.local/` bzw. `http://<device-name>.local/`
Angabe der IP-Adresse nicht mehr nötig.