### PR TITLE
Only call loop of radio modules that are enabled and set up

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -105,9 +105,11 @@ void app::setup() {
 void app::loop(void) {
     ah::Scheduler::loop();
 
-    mNrfRadio.loop();
+    if(mConfig->nrf.enabled)
+        mNrfRadio.loop();
     #if defined(ESP32)
-    mCmtRadio.loop();
+    if(mConfig->cmt.enabled)
+        mCmtRadio.loop();
     #endif
     mCommunication.loop();
 


### PR DESCRIPTION
Mir ist aufgefallen, dass auf meinem ESP32 Modul die CMT loop Funktion aufgerufen wird, obwohl ich gar kein solchese Modul habe und daher auch nicht enabled habe.