### PR TITLE
TimeMonitor class for overflow save timeout monitoring

### DIFF
--- a/src/hm/Communication.h
+++ b/src/hm/Communication.h
@@ -10,6 +10,7 @@
 #include <Arduino.h>
 #include "../utils/crc.h"
 #include "Heuristic.h"
+#include "../utils/timemonitor.h"
 
 #define MI_TIMEOUT          250 // timeout for MI type requests
 #define FRSTMSG_TIMEOUT     150 // how long to wait for first msg to be received
@@ -60,7 +61,7 @@ class Communication : public CommQueue<> {
                 mPrintSequenceDuration = true;
 
                 uint16_t timeout     = (q->iv->ivGen == IV_MI) ? MI_TIMEOUT : (((q->iv->mGotFragment && q->iv->mGotLastMsg) || mIsRetransmit) ? SINGLEFR_TIMEOUT : ((q->cmd != AlarmData) && (q->cmd != GridOnProFilePara) ? DEFAULT_TIMEOUT : (1.5 * DEFAULT_TIMEOUT)));
-                uint16_t timeout_min = (q->iv->ivGen == IV_MI) ? MI_TIMEOUT : ((q->iv->mGotFragment || mIsRetransmit)) ? SINGLEFR_TIMEOUT : FRSTMSG_TIMEOUT;
+                // uint16_t timeout_min = (q->iv->ivGen == IV_MI) ? MI_TIMEOUT : ((q->iv->mGotFragment || mIsRetransmit)) ? SINGLEFR_TIMEOUT : FRSTMSG_TIMEOUT;  // not used
 
                 /*if(mDebugState != mState) {
                     DPRINT(DBG_INFO, F("State: "));
@@ -69,8 +70,10 @@ class Communication : public CommQueue<> {
                 }*/
                 switch(mState) {
                     case States::RESET:
-                        if(millis() < mWaitTimeout)
+                        //if(millis() < mWaitTimeout)  // replaced by TimeMonitor
+                        if (!mWaitTime.isTimeout())
                             return;
+
                         mMaxFrameId = 0;
                         for(uint8_t i = 0; i < MAX_PAYLOAD_ENTRIES; i++) {
                             mLocalBuf[i].len = 0;
@@ -108,10 +111,11 @@ class Communication : public CommQueue<> {
                             q->iv->radio->prepareDevInformCmd(q->iv, q->cmd, q->ts, q->iv->alarmLastId, false);
 
                         q->iv->radioStatistics.txCnt++;
-                        mWaitTimeout     = millis() + timeout;
-                        mWaitTimeout_min = millis() + timeout_min;
+                        // mWaitTimeout     = millis() + timeout;  // replaced by Timemonitor
+                        mWaitTime.startTimeMonitor(timeout);
+                        // mWaitTimeout_min = millis() + timeout_min;  // not used
                         mIsRetransmit    = false;
-                        mlastTO_min      = timeout_min;
+                        // mlastTO_min      = timeout_min;  // not used
                         setAttempt();
                         if((q->cmd == AlarmData) || (q->cmd == GridOnProFilePara))
                             incrAttempt(q->cmd == AlarmData? 5 : 3);
@@ -120,7 +124,8 @@ class Communication : public CommQueue<> {
                         break;
 
                     case States::WAIT:
-                        if(millis() < mWaitTimeout)
+                        // if(millis() < mWaitTimeout)  // replaced by Timemonitor
+                        if (!mWaitTime.isTimeout())
                             return;
                         mState = States::CHECK_FRAMES;
                         break;
@@ -130,13 +135,15 @@ class Communication : public CommQueue<> {
                             if(*mSerialDebug) {
                                 DPRINT_IVID(DBG_INFO, q->iv->id);
                                 DBGPRINT(F("request timeout: "));
-                                DBGPRINT(String(millis() - mWaitTimeout + timeout));
+                                // DBGPRINT(String(millis() - mWaitTimeout + timeout));  // replaced by Timemonitor
+                                DBGPRINT(String(mWaitTime.getRunTime()));
                                 DBGPRINTLN(F("ms"));
                             }
                             if(!q->iv->mGotFragment) {
                                 if((IV_HMS == q->iv->ivGen) || (IV_HMT == q->iv->ivGen)) {
                                     q->iv->radio->switchFrequency(q->iv, HOY_BOOT_FREQ_KHZ, (q->iv->config->frequency*FREQ_STEP_KHZ + HOY_BASE_FREQ_KHZ));
-                                    mWaitTimeout = millis() + 1000;
+                                    //mWaitTimeout = millis() + 1000;  // replaced by Timemonitor
+                                    mWaitTime.startTimeMonitor(1000UL);
                                 }
                             }
                             closeRequest(q, false);
@@ -185,7 +192,8 @@ class Communication : public CommQueue<> {
                                 bool fastNext = true;
                                 if(q->iv->miMultiParts < 6) {
                                     mState = States::WAIT;
-                                    if((millis() > mWaitTimeout && mIsRetransmit) || !mIsRetransmit) {
+                                    // if((millis() > mWaitTimeout && mIsRetransmit) || !mIsRetransmit) {  // replaced by TimeMonitor
+                                    if((mWaitTime.isTimeout() && mIsRetransmit) || !mIsRetransmit) {
                                         miRepeatRequest(q);
                                         return;
                                     }
@@ -245,7 +253,7 @@ class Communication : public CommQueue<> {
                                 q->iv->mIsSingleframeReq = true;
                             sendRetransmit(q, (framnr-1));
                             mIsRetransmit = true;
-                            mlastTO_min = timeout_min;
+                            // mlastTO_min = timeout_min;  // not used
                             return;
                         }
 
@@ -492,7 +500,8 @@ class Communication : public CommQueue<> {
             if(q->attempts) {
                 q->iv->radio->sendCmdPacket(q->iv, TX_REQ_INFO, (SINGLE_FRAME + i), true);
                 q->iv->radioStatistics.retransmits++;
-                mWaitTimeout = millis() + SINGLEFR_TIMEOUT; // timeout
+                // mWaitTimeout = millis() + SINGLEFR_TIMEOUT; // timeout replaced by Timemonitor
+                mWaitTime.startTimeMonitor(SINGLEFR_TIMEOUT); // timeout
                 mState = States::WAIT;
             } else {
                 //add(q, true);
@@ -509,7 +518,8 @@ class Communication : public CommQueue<> {
                 q->iv->radioStatistics.rxFail++; // got no complete payload
             else
                 q->iv->radioStatistics.rxFailNoAnser++; // got nothing
-            mWaitTimeout = millis() + *mInverterGap;
+            // mWaitTimeout = millis() + *mInverterGap; // replaced by Timemonitor
+            mWaitTime.startTimeMonitor(*mInverterGap);
 
             bool keep = false;
             if(q->isDevControl)
@@ -731,8 +741,9 @@ class Communication : public CommQueue<> {
             //q->iv->radioStatistics.retransmits++;
             q->iv->radio->sendCmdPacket(q->iv, cmd, 0x00, true);
 
-            mWaitTimeout = millis() + MI_TIMEOUT;
-            mWaitTimeout_min = mWaitTimeout;
+            // mWaitTimeout = millis() + MI_TIMEOUT;  // replaced by TimeMonitor
+            // mWaitTimeout_min = mWaitTimeout;       // not used
+            mWaitTime.startTimeMonitor(MI_TIMEOUT);
             q->iv->miMultiParts = 0;
             q->iv->mGotFragment = 0;
             mIsRetransmit = true;
@@ -752,8 +763,9 @@ class Communication : public CommQueue<> {
 
             q->iv->radio->sendCmdPacket(q->iv, q->cmd, 0x00, true);
 
-            mWaitTimeout = millis() + MI_TIMEOUT;
-            mWaitTimeout_min = mWaitTimeout;
+            // mWaitTimeout = millis() + MI_TIMEOUT;  // replaced by TimeMonitor
+            // mWaitTimeout_min = mWaitTimeout;        // not used
+            mWaitTime.startTimeMonitor(MI_TIMEOUT);
             //mState = States::WAIT;
             mIsRetransmit = false;
         }
@@ -887,12 +899,12 @@ class Communication : public CommQueue<> {
         uint32_t *mTimestamp;
         bool *mPrivacyMode, *mSerialDebug, *mPrintWholeTrace;
         uint16_t *mInverterGap;
-        uint32_t mWaitTimeout     = 0;
-        uint32_t mWaitTimeout_min = 0;
+        TimeMonitor mWaitTime = TimeMonitor(0, true);  // start as expired (due to code in RESET state)
+       // uint32_t mWaitTimeout_min = 0;    // not used
         std::array<frame_t, MAX_PAYLOAD_ENTRIES> mLocalBuf;
         bool mFirstTry = false;                    // see, if we should do a second try
-        bool mIsRetransmit = false;                    // we alrady had waited one complete cycle
-        uint16_t mlastTO_min = DEFAULT_TIMEOUT;    // remember timeout_min for correct calculation
+        bool mIsRetransmit = false;                // we already had waited one complete cycle
+        // uint16_t mlastTO_min = DEFAULT_TIMEOUT;    // remember timeout_min for correct calculation  not used
         uint8_t mMaxFrameId;
         uint8_t mPayload[MAX_BUFFER];
         payloadListenerType mCbPayload = NULL;

--- a/src/plugins/Display/Display_Mono.h
+++ b/src/plugins/Display/Display_Mono.h
@@ -19,6 +19,7 @@
 #include "../../utils/helper.h"
 #include "Display_data.h"
 #include "../../utils/dbg.h"
+#include "../../utils/timemonitor.h"
 
 class DisplayMono {
    public:
@@ -37,19 +38,19 @@ class DisplayMono {
 
          if (mDisplayActive) {
             if (!dispConditions) {
-                if ((millis() - mStarttime) > DISP_DEFAULT_TIMEOUT * 1000ul) { // switch display off after timeout
+                if (mDisplayTime.isTimeout()) { // switch display off after timeout
                     mDisplayActive = false;
                     mDisplay->setPowerSave(true);
                     DBGPRINTLN("**** Display off ****");
                 }
             }
             else
-                mStarttime = millis();   // keep display on
+                mDisplayTime.reStartTimeMonitor(); // keep display on
          }
          else {
             if (dispConditions) {
-                mDisplayActive = true;  // switch display on
-                mStarttime = millis();
+                mDisplayActive = true;
+                mDisplayTime.reStartTimeMonitor(); // switch display on
                 mDisplay->setPowerSave(false);
                 DBGPRINTLN("**** Display on ****");
             }
@@ -79,7 +80,7 @@ class DisplayMono {
 
       uint8_t mExtra;
       int8_t  mPixelshift=0;
-      uint32_t mStarttime = millis();
+      TimeMonitor mDisplayTime = TimeMonitor(1000ul * 15, true);
       bool mDisplayActive = true;  // always start with display on
       char mFmtText[DISP_FMT_TEXT_LEN];
 

--- a/src/utils/timemonitor.h
+++ b/src/utils/timemonitor.h
@@ -1,0 +1,126 @@
+//-----------------------------------------------------------
+// You69Man, 2023
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// version 2 as published by the Free Software Foundation.
+//-----------------------------------------------------------
+
+/**
+ * @file timemonitor.h
+ *
+ * Class declaration for TimeMonitor
+ */
+
+#ifndef __TIMEMONITOR_H__
+#define __TIMEMONITOR_H__
+
+#include <Arduino.h>
+
+class TimeMonitor {
+    public:
+        /**
+         * A constructor for initializing a TimeMonitor
+         * @note TimeMonitor witch default constructor is stopped
+         */
+        TimeMonitor(void) {};
+
+        /**
+         * A constructor for initializing a TimeMonitor
+         * @param timeout timeout in ms
+         * @param start   (optional) if true, start TimeMonitor immediately
+         * @note TimeMonitor witch default constructor is stopped
+         */
+        TimeMonitor(uint32_t timeout, bool start = false) {
+            if (start)
+                startTimeMonitor(timeout);
+            else
+                configureTimeMonitor(timeout);
+        };
+
+        /**
+         * Start the TimeMonitor with new timeout configuration
+         * @param timeout timout in ms
+         */
+        void startTimeMonitor(uint32_t timeout) {
+            mStartTime = millis();
+            mTimeout = timeout;
+            mStarted = true;
+        }
+
+        /**
+         * Restart the TimeMonitor with already set timeout configuration
+         * @note returns nothing
+         */
+        void reStartTimeMonitor(void) {
+            mStartTime = millis();
+            mStarted = true;
+        }
+
+        /**
+         * Configure the TimeMonitor to new timeout configuration
+         * @param timeout timeout in ms
+         * @note This doesn't restart an already running TimeMonitor.
+         *       If timer is already running and new timeout is longer that current timeout runtime of the running timer is expanded
+         *       If timer is already running and new timeout is shorter that current timeout this can immediately lead to a timeout
+         */
+        void configureTimeMonitor(uint32_t timeout) {
+            mTimeout = timeout;
+        }
+
+        /**
+         * Stop the TimeMonitor
+         */
+        void stopTimeMonitor(void) {
+            mStarted = false;
+        }
+
+        /**
+         * Get timeout status of the TimeMonitor
+         * @return bool
+         *         true:  TimeMonitor already timed out
+         *         false: TimeMonitor still in time or TimeMonitor was stopped
+         */
+        bool isTimeout(void) {
+            if ((mStarted) && (millis() - mStartTime >= mTimeout))
+                return true;
+            else
+                return false;
+        }
+
+        /**
+         * Get timeout configuration of the TimeMonitor
+         * @return uint32_t timeout value in ms
+         */
+        uint32_t getTimeout(void) const {
+            return mTimeout;
+        }
+
+        /**
+         * Get residual time of the TimeMonitor until timeout
+         * @return uint32_t residual time until timeout in ms
+         * @note   in case of a stopped TimeMonitor residual time is always 0xFFFFFFFFUL
+         *         in case of a timed out TimeMonitor residual time is always 0UL (zero)
+         */
+        uint32_t getResidualTime(void) const {
+            uint32_t delayed =  millis() - mStartTime;
+            return(mStarted ? (delayed < mTimeout ? mTimeout - delayed : 0UL) : 0xFFFFFFFFUL);
+        }
+
+        /**
+         * Get overall run time of the TimeMonitor
+         * @return uint32_t residual time until timeout in ms
+         * @note   in case of a stopped TimeMonitor residual time is always 0xFFFFFFFFUL
+         *         in case of a timed out TimeMonitor residual time is always 0UL (zero)
+         */
+        uint32_t getRunTime(void) const {
+            return(mStarted ? millis() - mStartTime : 0UL);
+        }
+
+    private:
+        uint32_t mStartTime = 0UL;  // start time of the TimeMonitor
+        uint32_t mTimeout = 0UL;    // timeout configuration of the TimeMonitor
+        bool     mStarted = false;  // start/stop state of the TimeMonitor
+};
+
+#endif


### PR DESCRIPTION
Ich würde dem Projekt hiermit diese nützliche kleine TimerMonitor Klasse zur überlaufsicheren Überwachung von Timouts spendieren. Auch gleich mit fixes für #1244!