### PR TITLE
Enhancement: power graph display option

### DIFF
--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -166,6 +166,7 @@ typedef struct {
     bool pwrSaveAtIvOffline;
     uint8_t screenSaver;
     uint8_t graph_ratio;
+    uint8_t graph_size;
     uint8_t rot;
     //uint16_t wakeUp;
     //uint16_t sleepAt;
@@ -463,6 +464,7 @@ class settings {
             mCfg.plugin.display.contrast = 60;
             mCfg.plugin.display.screenSaver = 1;  // default: 1 .. pixelshift for OLED for downward compatibility
             mCfg.plugin.display.graph_ratio = 50;
+            mCfg.plugin.display.graph_size  = 2;
             mCfg.plugin.display.rot = 0;
             mCfg.plugin.display.disp_data  = DEF_PIN_OFF; // SDA
             mCfg.plugin.display.disp_clk   = DEF_PIN_OFF; // SCL
@@ -700,6 +702,7 @@ class settings {
                 disp[F("pwrSafe")]  = (bool)mCfg.plugin.display.pwrSaveAtIvOffline;
                 disp[F("screenSaver")] = mCfg.plugin.display.screenSaver;
                 disp[F("graph_ratio")] = mCfg.plugin.display.graph_ratio;
+                disp[F("graph_size")] = mCfg.plugin.display.graph_size;
                 disp[F("rotation")] = mCfg.plugin.display.rot;
                 //disp[F("wake")] = mCfg.plugin.display.wakeUp;
                 //disp[F("sleep")] = mCfg.plugin.display.sleepAt;
@@ -717,6 +720,7 @@ class settings {
                 getVal<bool>(disp, F("pwrSafe"), &mCfg.plugin.display.pwrSaveAtIvOffline);
                 getVal<uint8_t>(disp, F("screenSaver"), &mCfg.plugin.display.screenSaver);
                 getVal<uint8_t>(disp, F("graph_ratio"), &mCfg.plugin.display.graph_ratio);
+                getVal<uint8_t>(disp, F("graph_size"), &mCfg.plugin.display.graph_size);
                 getVal<uint8_t>(disp, F("rotation"), &mCfg.plugin.display.rot);
                 //mCfg.plugin.display.wakeUp = disp[F("wake")];
                 //mCfg.plugin.display.sleepAt = disp[F("sleep")];

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -165,6 +165,7 @@ typedef struct {
     uint8_t type;
     bool pwrSaveAtIvOffline;
     uint8_t screenSaver;
+    uint8_t graph_ratio;
     uint8_t rot;
     //uint16_t wakeUp;
     //uint16_t sleepAt;
@@ -461,6 +462,7 @@ class settings {
             mCfg.plugin.display.pwrSaveAtIvOffline = false;
             mCfg.plugin.display.contrast = 60;
             mCfg.plugin.display.screenSaver = 1;  // default: 1 .. pixelshift for OLED for downward compatibility
+            mCfg.plugin.display.graph_ratio = 50;
             mCfg.plugin.display.rot = 0;
             mCfg.plugin.display.disp_data  = DEF_PIN_OFF; // SDA
             mCfg.plugin.display.disp_clk   = DEF_PIN_OFF; // SCL
@@ -697,6 +699,7 @@ class settings {
                 disp[F("type")]     = mCfg.plugin.display.type;
                 disp[F("pwrSafe")]  = (bool)mCfg.plugin.display.pwrSaveAtIvOffline;
                 disp[F("screenSaver")] = mCfg.plugin.display.screenSaver;
+                disp[F("graph_ratio")] = mCfg.plugin.display.graph_ratio;
                 disp[F("rotation")] = mCfg.plugin.display.rot;
                 //disp[F("wake")] = mCfg.plugin.display.wakeUp;
                 //disp[F("sleep")] = mCfg.plugin.display.sleepAt;
@@ -713,6 +716,7 @@ class settings {
                 getVal<uint8_t>(disp, F("type"), &mCfg.plugin.display.type);
                 getVal<bool>(disp, F("pwrSafe"), &mCfg.plugin.display.pwrSaveAtIvOffline);
                 getVal<uint8_t>(disp, F("screenSaver"), &mCfg.plugin.display.screenSaver);
+                getVal<uint8_t>(disp, F("graph_ratio"), &mCfg.plugin.display.graph_ratio);
                 getVal<uint8_t>(disp, F("rotation"), &mCfg.plugin.display.rot);
                 //mCfg.plugin.display.wakeUp = disp[F("wake")];
                 //mCfg.plugin.display.sleepAt = disp[F("sleep")];

--- a/src/plugins/Display/Display.h
+++ b/src/plugins/Display/Display.h
@@ -165,6 +165,9 @@ class Display {
         else
             mDisplayData.utcTs = 0;
 
+        mDisplayData.pGraphStartTime = mApp->getSunrise();
+        mDisplayData.pGraphEndTime = mApp->getSunset();
+
         if (mMono ) {
             mMono->disp();
         }

--- a/src/plugins/Display/Display.h
+++ b/src/plugins/Display/Display.h
@@ -54,7 +54,7 @@ class Display {
             default: mMono = NULL; break;
         }
         if(mMono) {
-            mMono->config(mCfg->pwrSaveAtIvOffline, mCfg->screenSaver, mCfg->contrast);
+            mMono->config(mCfg->pwrSaveAtIvOffline, mCfg->screenSaver, mCfg->contrast, mCfg->graph_ratio);
             mMono->init(mCfg->type, mCfg->rot, mCfg->disp_cs, mCfg->disp_dc, 0xff, mCfg->disp_clk, mCfg->disp_data, &mDisplayData);
         }
 
@@ -75,10 +75,12 @@ class Display {
     }
 
     void tickerSecond() {
-        if (mMono != NULL)
-            mMono->loop(mCfg->contrast, motionSensorActive());
+        bool request_refresh = false;
 
-        if (mNewPayload || (((++mLoopCnt) % 5) == 0)) {
+        if (mMono != NULL)
+            request_refresh = mMono->loop(mCfg->contrast, motionSensorActive());
+
+        if (mNewPayload || (((++mLoopCnt) % 5) == 0) || request_refresh) {
             DataScreen();
             mNewPayload = false;
             mLoopCnt = 0;

--- a/src/plugins/Display/Display.h
+++ b/src/plugins/Display/Display.h
@@ -54,7 +54,7 @@ class Display {
             default: mMono = NULL; break;
         }
         if(mMono) {
-            mMono->config(mCfg->pwrSaveAtIvOffline, mCfg->screenSaver, mCfg->contrast, mCfg->graph_ratio);
+            mMono->config(mCfg->pwrSaveAtIvOffline, mCfg->screenSaver, mCfg->contrast, mCfg->graph_ratio, mCfg->graph_size);
             mMono->init(mCfg->type, mCfg->rot, mCfg->disp_cs, mCfg->disp_dc, 0xff, mCfg->disp_clk, mCfg->disp_data, &mDisplayData);
         }
 

--- a/src/plugins/Display/Display_Mono.h
+++ b/src/plugins/Display/Display_Mono.h
@@ -26,7 +26,7 @@ class DisplayMono {
       DisplayMono() {};
 
       virtual void init(uint8_t type, uint8_t rot, uint8_t cs, uint8_t dc, uint8_t reset, uint8_t clock, uint8_t data, DisplayData *displayData) = 0;
-      virtual void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum, uint8_t graph_ratio) = 0;
+      virtual void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum, uint8_t graph_ratio, uint8_t graph_size) = 0;
       virtual void disp(void) = 0;
 
       // Common loop function, manages display on/off functions for powersave and screensaver with motionsensor
@@ -85,6 +85,7 @@ class DisplayMono {
       uint8_t mScreenSaver = 1;  // 0 .. off; 1 .. pixelShift; 2 .. motionsensor
       uint8_t mLuminance;
       uint8_t mGraphRatio;
+      uint8_t mGraphSize;
 
       uint8_t mLoopCnt;
       uint8_t mLineXOffsets[5] = {};
@@ -119,7 +120,7 @@ class DisplayMono {
          if (mGraphRatio == 100)           // if graph ratio is 100% start in graph mode
             mDispSwitchState = d_POWER_GRAPH;
          else if (mGraphRatio != 0)
-            mDispSwitchTime.startTimeMonitor(150 * (100 - mGraphRatio));  // start time monitor only if ratio is neither 0 nor 100
+            mDispSwitchTime.startTimeMonitor(150 * (100 - mGraphRatio));  // start display mode change only if ratio is neither 0 nor 100
       }
 
       bool monoMaintainDispSwitchState(void) {

--- a/src/plugins/Display/Display_Mono.h
+++ b/src/plugins/Display/Display_Mono.h
@@ -60,11 +60,22 @@ class DisplayMono {
             mLuminance = lum;
             mDisplay->setContrast(mLuminance);
          }
+
+         monoMaintainDispSwitchState();
       }
 
    protected:
       U8G2* mDisplay;
       DisplayData *mDisplayData;
+
+      float  *mPgData=nullptr;
+      uint8_t mPgWidth=0;
+      uint8_t mPgHeight=0;
+      float   mPgMaxPwr=0.0;
+//      float   mPgMaxAvailPower = 0.0;
+      uint32_t mPgPeriod=0; // seconds
+      uint32_t mPgTimeOfDay=0;
+      uint8_t  mPgLastPos=0;
 
       uint8_t mType;
       uint16_t mDispWidth;
@@ -81,8 +92,15 @@ class DisplayMono {
       uint8_t mExtra;
       int8_t  mPixelshift=0;
       TimeMonitor mDisplayTime = TimeMonitor(1000 * DISP_DEFAULT_TIMEOUT, true);
+      TimeMonitor mDispSwitchTime = TimeMonitor(10000, true);
+      uint8_t mDispSwitchState = 0;
       bool mDisplayActive = true;  // always start with display on
       char mFmtText[DISP_FMT_TEXT_LEN];
+
+      enum _dispSwitchState {
+         d_POWER_TEXT = 0,
+         d_POWER_GRAPH = 1,
+      };
 
       // Common initialization function to be called by subclasses
       void monoInit(U8G2* display, uint8_t type, DisplayData *displayData) {
@@ -97,6 +115,133 @@ class DisplayMono {
          mDispHeight = mDisplay->getDisplayHeight();
       }
 
+      void monoMaintainDispSwitchState(void) {
+         switch(mDispSwitchState) {
+            case d_POWER_TEXT:
+               if (mDispSwitchTime.isTimeout()) {
+                  mDispSwitchState = d_POWER_GRAPH;
+                  mDispSwitchTime.startTimeMonitor(5000);
+               }
+               break;
+            case d_POWER_GRAPH:
+               if (mDispSwitchTime.isTimeout()) {
+                  mDispSwitchState = d_POWER_TEXT;
+                  mDispSwitchTime.startTimeMonitor(10000);
+               }
+               break;
+         }
+      }
+
+      void initPowerGraph(uint8_t width, uint8_t height) {
+         mPgWidth = width;
+         mPgHeight = height;
+         mPgData = new float[mPgWidth];
+         //memset(mPgData, 0, mPgWidth);
+         resetPowerGraph();
+/*
+         Inverter<> *iv;
+         mPgMaxAvailPower = 0;
+         uint8_t nInv = mSys->getNumInverters();
+         for (uint8_t i = 0; i < nInv; i++) {
+            iv = mSys->getInverterByPos(i);
+            if (iv == NULL)
+               continue;
+            for (uint8_t ch = 0; ch < 6; ch++) {
+               mPgMaxAvailPower += iv->config->chMaxPwr[ch];
+            }
+         }
+         DBGPRINTLN("max. Power = " + String(mPgMaxAvailPower));*/
+      }
+
+      void resetPowerGraph() {
+        if (mPgData != nullptr) {
+           mPgMaxPwr = 0.0;
+           mPgLastPos = 0;
+           for (uint8_t i = 0; i < mPgWidth; i++)
+              mPgData[i] = 0.0;
+        }
+      }
+
+      uint8_t sss2pgpos(uint seconds_since_start) {
+        return(seconds_since_start * (mPgWidth - 1) / (mDisplayData->pGraphEndTime - mDisplayData->pGraphStartTime));
+      }
+
+      void calcPowerGraphValues() {
+         mPgPeriod = mDisplayData->pGraphEndTime - mDisplayData->pGraphStartTime;  // length of power graph for scaling of x-axis
+         uint32_t oldTimeOfDay = mPgTimeOfDay;
+         mPgTimeOfDay = (mDisplayData->utcTs > mDisplayData->pGraphStartTime) ? mDisplayData->utcTs - mDisplayData->pGraphStartTime : 0; // current time of day with respect to current sunrise time
+         if (oldTimeOfDay > mPgTimeOfDay) // new day -> reset old data
+            resetPowerGraph();
+         mPgLastPos = std::min((uint8_t) (mPgTimeOfDay * (mPgWidth - 1) / mPgPeriod), (uint8_t) (mPgWidth - 1));  // current datapoint based on currenct time of day
+      }
+
+      void addPowerGraphEntry(float val) {
+         if (mDisplayData->utcTs > 0) {  // precondition: utc time available
+            calcPowerGraphValues();
+            //mPgData[mPgLastPos] = std::max(mPgData[mPgLastPos], (uint8_t) (val * 255.0 / mPgMaxAvailPower));  // normalizing of data to 0-255
+            mPgData[mPgLastPos] = std::max(mPgData[mPgLastPos], val);
+            mPgMaxPwr = std::max(mPgMaxPwr, val);  // max value of stored data for scaling of y-axis
+         }
+      }
+
+      uint8_t getPowerGraphXpos(uint8_t p) {  //
+        if ((p <= mPgLastPos) && (mPgLastPos > 0))
+            return((p * (mPgWidth - 1)) / mPgLastPos);  // scaling of x-axis
+        else
+            return(0);
+      }
+
+      uint8_t getPowerGraphYpos(uint8_t p) {
+        if (p < mPgWidth)
+            //return(((uint32_t) mPgData[p] * (uint32_t) mPgMaxAvailPower) * (uint32_t) mPgHeight / mPgMaxPwr / 255); // scaling of normalized data (0-255) to graph height
+            return((mPgData[p] * (uint32_t) mPgHeight / mPgMaxPwr)); // scaling of data to graph height
+        else
+            return(0);
+      }
+
+      void plotPowerGraph(uint8_t xoff, uint8_t yoff) {
+        // draw axes
+        mDisplay->drawLine(xoff, yoff, xoff,            yoff - mPgHeight);  // vertical axis
+        mDisplay->drawLine(xoff, yoff, xoff + mPgWidth, yoff);              // horizontal axis
+
+        // draw X scale
+        tmElements_t tm;
+        breakTime(mDisplayData->pGraphEndTime, tm);
+        uint8_t endHourPg = tm.Hour;
+        breakTime(mDisplayData->utcTs, tm);
+        uint8_t endHour = std::min(endHourPg, tm.Hour);
+        breakTime(mDisplayData->pGraphStartTime, tm);
+        tm.Hour += 1;
+        tm.Minute = 0;
+        tm.Second = 0;
+        for (; tm.Hour <= endHour; tm.Hour++) {
+            uint8_t x_pos_screen = getPowerGraphXpos(sss2pgpos((uint32_t) makeTime(tm) - mDisplayData->pGraphStartTime)); // scale horizontal axis
+            mDisplay->drawPixel(xoff + x_pos_screen, yoff - 1);
+        }
+
+        // draw Y scale
+        uint16_t scale_y = 10;
+        uint32_t maxpwr_int = static_cast<uint8_t>(std::round(mPgMaxPwr));
+        if (maxpwr_int > 100)
+            scale_y = 100;
+        for (uint32_t i = scale_y; i <= maxpwr_int; i += scale_y) {
+            uint8_t ypos = yoff - static_cast<uint8_t>(std::round(i * (float) mPgHeight / mPgMaxPwr)); // scale vertical axis
+            mDisplay->drawPixel(xoff + 1, ypos);
+        }
+
+        // draw curve
+        for (uint8_t i = 1; i <= mPgLastPos; i++) {
+            mDisplay->drawLine(xoff + getPowerGraphXpos(i - 1), yoff - getPowerGraphYpos(i - 1),
+                               xoff + getPowerGraphXpos(i),     yoff - getPowerGraphYpos(i));
+        }
+
+        // print max power value
+        mDisplay->setFont(u8g2_font_4x6_tr);
+        snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%dW", static_cast<uint16_t>(std::round(mPgMaxPwr)));
+        mDisplay->drawStr(xoff + 3, yoff - mPgHeight + 5, mFmtText);
+      }
+
+      // pixelshift screensaver with wipe effect
       void calcPixelShift(int range) {
          int8_t mod = (millis() / 10000) % ((range >> 1) << 2);
          mPixelshift = mScreenSaver == 1 ? ((mod < range) ? mod - (range >> 1) : -(mod - range - (range >> 1) + 1)) : 0;

--- a/src/plugins/Display/Display_Mono_128X32.h
+++ b/src/plugins/Display/Display_Mono_128X32.h
@@ -12,11 +12,12 @@ class DisplayMono128X32 : public DisplayMono {
             mExtra = 0;
         }
 
-        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum, uint8_t graph_ratio) {
+        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum, uint8_t graph_ratio, uint8_t graph_size) {
             mEnPowerSave = enPowerSave;
             mScreenSaver = screenSaver;
             mLuminance = lum;
             mGraphRatio = graph_ratio;
+            mGraphSize  = graph_size;
         }
 
         void init(uint8_t type, uint8_t rotation, uint8_t cs, uint8_t dc, uint8_t reset, uint8_t clock, uint8_t data, DisplayData *displayData) {

--- a/src/plugins/Display/Display_Mono_128X32.h
+++ b/src/plugins/Display/Display_Mono_128X32.h
@@ -12,10 +12,11 @@ class DisplayMono128X32 : public DisplayMono {
             mExtra = 0;
         }
 
-        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum) {
+        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum, uint8_t graph_ratio) {
             mEnPowerSave = enPowerSave;
             mScreenSaver = screenSaver;
             mLuminance = lum;
+            mGraphRatio = graph_ratio;
         }
 
         void init(uint8_t type, uint8_t rotation, uint8_t cs, uint8_t dc, uint8_t reset, uint8_t clock, uint8_t data, DisplayData *displayData) {

--- a/src/plugins/Display/Display_Mono_128X64.h
+++ b/src/plugins/Display/Display_Mono_128X64.h
@@ -34,6 +34,8 @@ class DisplayMono128X64 : public DisplayMono {
             }
             calcLinePositions();
 
+            initPowerGraph(mDispWidth - 20, mLineYOffsets[4] - mLineYOffsets[1]);
+
             printText("Ahoy!", l_Ahoy, 0xff);
             printText("ahoydtu.de", l_Website, 0xff);
             printText(mDisplayData->version, l_Version, 0xff);
@@ -61,23 +63,16 @@ class DisplayMono128X64 : public DisplayMono {
             // calculate current pixelshift for pixelshift screensaver
             calcPixelShift(pixelShiftRange);
 
-            // print total power
+            // add new power data to power graph
             if (mDisplayData->nrProducing > 0) {
-                if (mDisplayData->totalPower > 9999.0)
-                    snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.2f kW", (mDisplayData->totalPower / 1000.0));
-                else
-                    snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.0f W", mDisplayData->totalPower);
-
-                printText(mFmtText, l_TotalPower, 0xff);
-            } else {
-                printText("offline", l_TotalPower, 0xff);
+                addPowerGraphEntry(mDisplayData->totalPower);
             }
 
             // print Date and time
             if (0 != mDisplayData->utcTs)
                 printText(ah::getDateTimeStrShort(gTimezone.toLocal(mDisplayData->utcTs)).c_str(), l_Time, 0xff);
 
-            // dynamic status bar, alternatively:
+            // alternatively:
             // print ip address
             if (!(mExtra % 5) && (mDisplayData->ipAddress)) {
                 snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%s", (mDisplayData->ipAddress).toString().c_str());
@@ -115,22 +110,41 @@ class DisplayMono128X64 : public DisplayMono {
                     mDisplay->drawStr(pos + moon_pos + mPixelshift, mLineYOffsets[l_Status], "H");    // moon symbol
             }
 
-            // print yields
-            mDisplay->setFont(u8g2_font_ncenB10_symbols10_ahoy);
-            mDisplay->drawStr(16 + mPixelshift, mLineYOffsets[l_YieldDay],   "I");    // day symbol
-            mDisplay->drawStr(16 + mPixelshift, mLineYOffsets[l_YieldTotal], "D");    // total symbol
+            if (mDispSwitchState == d_POWER_TEXT) {
 
-            if (mDisplayData->totalYieldDay > 9999.0)
-                snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.2f kWh", mDisplayData->totalYieldDay / 1000.0);
-            else
-                snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.0f Wh", mDisplayData->totalYieldDay);
-            printText(mFmtText, l_YieldDay, 0xff);
+                // print total power
+                if (mDisplayData->nrProducing > 0) {
+                    if (mDisplayData->totalPower > 9999.0)
+                        snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.2f kW", (mDisplayData->totalPower / 1000.0));
+                    else
+                        snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.0f W", mDisplayData->totalPower);
 
-            if (mDisplayData->totalYieldTotal > 9999.0)
-                snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.2f MWh", mDisplayData->totalYieldTotal / 1000.0);
-            else
-                snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.0f kWh", mDisplayData->totalYieldTotal);
-            printText(mFmtText, l_YieldTotal, 0xff);
+                    printText(mFmtText, l_TotalPower, 0xff);
+                } else {
+                    printText("offline", l_TotalPower, 0xff);
+                }
+
+                // print yields
+                mDisplay->setFont(u8g2_font_ncenB10_symbols10_ahoy);
+                mDisplay->drawStr(16 + mPixelshift, mLineYOffsets[l_YieldDay],   "I");    // day symbol
+                mDisplay->drawStr(16 + mPixelshift, mLineYOffsets[l_YieldTotal], "D");    // total symbol
+
+                if (mDisplayData->totalYieldDay > 9999.0)
+                    snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.2f kWh", mDisplayData->totalYieldDay / 1000.0);
+                else
+                    snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.0f Wh", mDisplayData->totalYieldDay);
+                printText(mFmtText, l_YieldDay, 0xff);
+
+                if (mDisplayData->totalYieldTotal > 9999.0)
+                    snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.2f MWh", mDisplayData->totalYieldTotal / 1000.0);
+                else
+                    snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%.0f kWh", mDisplayData->totalYieldTotal);
+                printText(mFmtText, l_YieldTotal, 0xff);
+
+            } else {
+                // plot power graph
+                plotPowerGraph(10 + mPixelshift, mLineYOffsets[4] - 1);
+            }
 
             // draw dynamic RSSI bars
             int xoffs;
@@ -142,10 +156,11 @@ class DisplayMono128X64 : public DisplayMono {
             for (int i = 0; i < 4; i++) {
                 int radio_rssi_threshold = -60 - i * 10;
                 int wifi_rssi_threshold = -60 - i * 10;
+                uint8_t barwidth = std::min(4 - i, 3);
                 if (mDisplayData->RadioRSSI > radio_rssi_threshold)
-                    mDisplay->drawBox(xoffs + mPixelshift, 8 + (rssi_bar_height + 1) * i, 4 - i, rssi_bar_height);
+                    mDisplay->drawBox(xoffs + mPixelshift,                         8 + (rssi_bar_height + 1) * i, barwidth, rssi_bar_height);
                 if (mDisplayData->WifiRSSI > wifi_rssi_threshold)
-                    mDisplay->drawBox(mDispWidth - 4 - xoffs + mPixelshift + i, 8 + (rssi_bar_height + 1) * i, 4 - i, rssi_bar_height);
+                    mDisplay->drawBox(mDispWidth - barwidth - xoffs + mPixelshift, 8 + (rssi_bar_height + 1) * i, barwidth, rssi_bar_height);
             }
             // draw dynamic antenna and WiFi symbols
             mDisplay->setFont(u8g2_font_ncenB10_symbols10_ahoy);
@@ -158,9 +173,6 @@ class DisplayMono128X64 : public DisplayMono {
             else
                 sym[0] = mDisplayData->WifiSymbol?'B':'F';              // Wifi
             mDisplay->drawStr(mDispWidth - mDisplay->getStrWidth(sym) - xoffs + mPixelshift, mLineYOffsets[l_RSSI], sym);
-            mDisplay->sendBuffer();
-
-
             mDisplay->sendBuffer();
 
             mExtra++;
@@ -198,8 +210,8 @@ class DisplayMono128X64 : public DisplayMono {
                 mLineYOffsets[i] = yOff;
                 dsc = mDisplay->getDescent();
                 yOff -= dsc;
-                if (l_Time==i)   // prevent time and status line to touch
-                    yOff+=1;     // -> one pixels space
+                if (l_Time == i)   // prevent time and status line to touch
+                    yOff++;     // -> one pixels space
                 i++;
             } while(l_MAX_LINES>i);
         }

--- a/src/plugins/Display/Display_Mono_128X64.h
+++ b/src/plugins/Display/Display_Mono_128X64.h
@@ -12,10 +12,11 @@ class DisplayMono128X64 : public DisplayMono {
             mExtra = 0;
         }
 
-        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum) {
+        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum, uint8_t graph_ratio) {
             mEnPowerSave = enPowerSave;
             mScreenSaver = screenSaver;
             mLuminance = lum;
+            mGraphRatio = graph_ratio;
         }
 
         void init(uint8_t type, uint8_t rotation, uint8_t cs, uint8_t dc, uint8_t reset, uint8_t clock, uint8_t data, DisplayData *displayData) {

--- a/src/plugins/Display/Display_Mono_64X48.h
+++ b/src/plugins/Display/Display_Mono_64X48.h
@@ -12,10 +12,11 @@ class DisplayMono64X48 : public DisplayMono {
             mExtra = 0;
         }
 
-        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum) {
+        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum, uint8_t graph_ratio) {
             mEnPowerSave = enPowerSave;
             mScreenSaver = screenSaver;
             mLuminance = lum;
+            mGraphRatio = graph_ratio;
         }
 
         void init(uint8_t type, uint8_t rotation, uint8_t cs, uint8_t dc, uint8_t reset, uint8_t clock, uint8_t data, DisplayData *displayData) {

--- a/src/plugins/Display/Display_Mono_64X48.h
+++ b/src/plugins/Display/Display_Mono_64X48.h
@@ -12,11 +12,12 @@ class DisplayMono64X48 : public DisplayMono {
             mExtra = 0;
         }
 
-        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum, uint8_t graph_ratio) {
+        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum, uint8_t graph_ratio, uint8_t graph_size) {
             mEnPowerSave = enPowerSave;
             mScreenSaver = screenSaver;
             mLuminance = lum;
             mGraphRatio = graph_ratio;
+            mGraphSize  = graph_size;
         }
 
         void init(uint8_t type, uint8_t rotation, uint8_t cs, uint8_t dc, uint8_t reset, uint8_t clock, uint8_t data, DisplayData *displayData) {

--- a/src/plugins/Display/Display_Mono_84X48.h
+++ b/src/plugins/Display/Display_Mono_84X48.h
@@ -12,10 +12,11 @@ class DisplayMono84X48 : public DisplayMono {
             mExtra = 0;
         }
 
-        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum) {
+        void config(bool enPowerSave, uint8_t screenSaver, uint8_t lum, uint8_t graph_ratio) {
             mEnPowerSave = enPowerSave;
             mScreenSaver = screenSaver;
             mLuminance = lum;
+            mGraphRatio = graph_ratio;
         }
 
         void init(uint8_t type, uint8_t rotation, uint8_t cs, uint8_t dc, uint8_t reset, uint8_t clock, uint8_t data, DisplayData *displayData) {

--- a/src/plugins/Display/Display_data.h
+++ b/src/plugins/Display/Display_data.h
@@ -9,6 +9,8 @@ struct DisplayData {
     float totalYieldDay=0.0f;   // indicate day yield (Wh)
     float totalYieldTotal=0.0f; // indicate total yield (kWh)
     uint32_t utcTs=0;           // indicate absolute timestamp (utc unix time). 0 = time is not synchonized
+    uint32_t pGraphStartTime=0; // starttime for power graph (e.g. sunRise)
+    uint32_t pGraphEndTime=0;   // starttime for power graph (e.g. sunSet)
     uint8_t nrProducing=0;      // indicate number of producing inverters
     uint8_t nrSleeping=0;       // indicate number of sleeping inverters
     bool WifiSymbol = false;    // indicate if WiFi is connected

--- a/src/web/RestApi.h
+++ b/src/web/RestApi.h
@@ -671,18 +671,19 @@ class RestApi {
         }
 
         void getDisplay(JsonObject obj) {
-            obj[F("disp_typ")]     = (uint8_t)mConfig->plugin.display.type;
-            obj[F("disp_pwr")]     = (bool)mConfig->plugin.display.pwrSaveAtIvOffline;
-            obj[F("disp_screensaver")] = (uint8_t)mConfig->plugin.display.screenSaver;
-            obj[F("disp_rot")]     = (uint8_t)mConfig->plugin.display.rot;
-            obj[F("disp_cont")]    = (uint8_t)mConfig->plugin.display.contrast;
-            obj[F("disp_clk")]     = (mConfig->plugin.display.type == 0) ? DEF_PIN_OFF : mConfig->plugin.display.disp_clk;
-            obj[F("disp_data")]    = (mConfig->plugin.display.type == 0) ? DEF_PIN_OFF : mConfig->plugin.display.disp_data;
-            obj[F("disp_cs")]      = (mConfig->plugin.display.type < 3)  ? DEF_PIN_OFF : mConfig->plugin.display.disp_cs;
-            obj[F("disp_dc")]      = (mConfig->plugin.display.type < 3)  ? DEF_PIN_OFF : mConfig->plugin.display.disp_dc;
-            obj[F("disp_rst")]     = (mConfig->plugin.display.type < 3)  ? DEF_PIN_OFF : mConfig->plugin.display.disp_reset;
-            obj[F("disp_bsy")]     = (mConfig->plugin.display.type < 10) ? DEF_PIN_OFF : mConfig->plugin.display.disp_busy;
-            obj[F("pir_pin")]      =  mConfig->plugin.display.pirPin;
+            obj[F("disp_typ")]          = (uint8_t)mConfig->plugin.display.type;
+            obj[F("disp_pwr")]          = (bool)mConfig->plugin.display.pwrSaveAtIvOffline;
+            obj[F("disp_screensaver")]  = (uint8_t)mConfig->plugin.display.screenSaver;
+            obj[F("disp_rot")]          = (uint8_t)mConfig->plugin.display.rot;
+            obj[F("disp_cont")]         = (uint8_t)mConfig->plugin.display.contrast;
+            obj[F("disp_graph_ratio")]  = (uint8_t)mConfig->plugin.display.graph_ratio;
+            obj[F("disp_clk")]          = (mConfig->plugin.display.type == 0) ? DEF_PIN_OFF : mConfig->plugin.display.disp_clk;
+            obj[F("disp_data")]         = (mConfig->plugin.display.type == 0) ? DEF_PIN_OFF : mConfig->plugin.display.disp_data;
+            obj[F("disp_cs")]           = (mConfig->plugin.display.type < 3)  ? DEF_PIN_OFF : mConfig->plugin.display.disp_cs;
+            obj[F("disp_dc")]           = (mConfig->plugin.display.type < 3)  ? DEF_PIN_OFF : mConfig->plugin.display.disp_dc;
+            obj[F("disp_rst")]          = (mConfig->plugin.display.type < 3)  ? DEF_PIN_OFF : mConfig->plugin.display.disp_reset;
+            obj[F("disp_bsy")]          = (mConfig->plugin.display.type < 10) ? DEF_PIN_OFF : mConfig->plugin.display.disp_busy;
+            obj[F("pir_pin")]           =  mConfig->plugin.display.pirPin;
         }
 
         void getMqttInfo(JsonObject obj) {

--- a/src/web/RestApi.h
+++ b/src/web/RestApi.h
@@ -677,6 +677,7 @@ class RestApi {
             obj[F("disp_rot")]          = (uint8_t)mConfig->plugin.display.rot;
             obj[F("disp_cont")]         = (uint8_t)mConfig->plugin.display.contrast;
             obj[F("disp_graph_ratio")]  = (uint8_t)mConfig->plugin.display.graph_ratio;
+            obj[F("disp_graph_size")]   = (uint8_t)mConfig->plugin.display.graph_size;
             obj[F("disp_clk")]          = (mConfig->plugin.display.type == 0) ? DEF_PIN_OFF : mConfig->plugin.display.disp_clk;
             obj[F("disp_data")]         = (mConfig->plugin.display.type == 0) ? DEF_PIN_OFF : mConfig->plugin.display.disp_data;
             obj[F("disp_cs")]           = (mConfig->plugin.display.type < 3)  ? DEF_PIN_OFF : mConfig->plugin.display.disp_cs;

--- a/src/web/html/setup.html
+++ b/src/web/html/setup.html
@@ -294,6 +294,15 @@
                         <p class="des">{#DISP_PINOUT}</p>
                         <div id="dispPins"></div>
                         <div id="pirPin"></div>
+                        <p class="des">Graph options</p>
+                        <div class="row mb-3">
+                            <div class="col-12 col-sm-3 my-2">Graph Size</div>
+                            <div class="col-12 col-sm-9"><input type="number" name="graph_size" min="0" max="255"></select></div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-12 col-sm-3 my-2">Show ratio (0-100 %)</div>
+                            <div class="col-12 col-sm-9"><input type="number" name="disp_graph_ratio" min="0" max="100"></select></div>
+                        </div>
                     </fieldset>
                     </div>
 
@@ -1086,6 +1095,8 @@
                 document.getElementById("disp_screensaver").addEventListener('change', function(e) {
                     hideDispPins(pins, parseInt(dtype_sel.value))
                 });
+
+                document.getElementsByName("disp_graph_ratio")[0].value = obj["disp_graph_ratio"];
 
                 hideDispPins(pins, obj.disp_typ);
             }

--- a/src/web/html/setup.html
+++ b/src/web/html/setup.html
@@ -295,10 +295,7 @@
                         <div id="dispPins"></div>
                         <div id="pirPin"></div>
                         <p class="des">Graph options</p>
-                        <div class="row mb-3">
-                            <div class="col-12 col-sm-3 my-2">Graph Size</div>
-                            <div class="col-12 col-sm-9"><input type="number" name="graph_size" min="0" max="255"></select></div>
-                        </div>
+                        <div id="graphSize"></div>
                         <div class="row mb-3">
                             <div class="col-12 col-sm-3 my-2">Show ratio (0-100 %)</div>
                             <div class="col-12 col-sm-9"><input type="number" name="disp_graph_ratio" min="0" max="100"></select></div>
@@ -1097,6 +1094,16 @@
                 });
 
                 document.getElementsByName("disp_graph_ratio")[0].value = obj["disp_graph_ratio"];
+
+                var opts2 = [[0, "Line 1 - 2"], [1, "Line 2 - 3"], [2, "Line 1 - 3"], [3, "Line 2 - 4"], [4, "Line 1 - 4"]];
+                var graph_size_sel = sel("disp_graph_size", opts2, obj["disp_graph_size"]);
+                graph_size_sel.id = 'disp_graph_size';
+                document.getElementById("graphSize").append(
+                    ml("div", {class: "row mb-3"}, [
+                        ml("div", {class: "col-12 col-sm-3 my-2"}, "Graph size"),
+                        ml("div", {class: "col-12 col-sm-9"}, graph_size_sel)
+                    ])
+                );
 
                 hideDispPins(pins, obj.disp_typ);
             }

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -584,6 +584,7 @@ class Web {
             // display
             mConfig->plugin.display.pwrSaveAtIvOffline = (request->arg("disp_pwr") == "on");
             mConfig->plugin.display.screenSaver = request->arg("disp_screensaver").toInt();
+            mConfig->plugin.display.graph_ratio = request->arg("disp_graph_ratio").toInt();
             mConfig->plugin.display.rot        = request->arg("disp_rot").toInt();
             mConfig->plugin.display.type       = request->arg("disp_typ").toInt();
             mConfig->plugin.display.contrast   = (mConfig->plugin.display.type == 0) ? 60 : request->arg("disp_cont").toInt();

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -585,6 +585,7 @@ class Web {
             mConfig->plugin.display.pwrSaveAtIvOffline = (request->arg("disp_pwr") == "on");
             mConfig->plugin.display.screenSaver = request->arg("disp_screensaver").toInt();
             mConfig->plugin.display.graph_ratio = request->arg("disp_graph_ratio").toInt();
+            mConfig->plugin.display.graph_size  = request->arg("disp_graph_size").toInt();
             mConfig->plugin.display.rot        = request->arg("disp_rot").toInt();
             mConfig->plugin.display.type       = request->arg("disp_typ").toInt();
             mConfig->plugin.display.contrast   = (mConfig->plugin.display.type == 0) ? 60 : request->arg("disp_cont").toInt();


### PR DESCRIPTION
**Display Graph für Anzeige des Leistungs-Tagesertrages**

Features:
* Flexible Größe des Graphen (konfigurierbar in 5 verschiedene Varianten)
* Konfigurierbare Anzeigedauer in % für Umschaltung zwischen Text- und Graph-Anzeige
* Unterstützung der 84x48 und 128x64 Displays
* Automatische vertikale Skalierung auf Leistungs-Maximalwert 
* Anzeige des Tages- Leistungs-Maximalwerts 
* Automatische horizontale Skalierung auf Basis sunrise und sunset
* Skala für Stunden und Leistung
* Graph bleibt über Nacht stehen, bis zum nächsten Tagesanbruch
* Kompatibel mit Pixelshift screensaver (downscale)
* Speicherschonend (nur notwendige Werte je Display Pixel im RAM gespeichert)
    -> könnte theroretisch noch weiter durch Normierung vom floats auf uint8 reduziert werden (ist vorbereitet, falls Bedenken wegen RAM)
* Getestet mit ESP8266 und ESP32