### PR TITLE
Pin selection for ESP-32 S2

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -195,6 +195,11 @@ build_flags = ${env.build_flags}
     -DDEF_NRF_MISO_PIN=9
     -DDEF_NRF_MOSI_PIN=11
     -DDEF_NRF_SCLK_PIN=7
+    -DDEF_CMT_CSB=16
+    -DDEF_CMT_FCSB=18
+    -DDEF_CMT_IRQ=33
+    -DDEF_CMT_SDIO=35
+    -DDEF_CMT_SCLK=37
 monitor_filters =
     esp32_exception_decoder
 
@@ -209,6 +214,11 @@ build_flags = ${env.build_flags}
     -DDEF_NRF_MISO_PIN=9
     -DDEF_NRF_MOSI_PIN=11
     -DDEF_NRF_SCLK_PIN=7
+    -DDEF_CMT_CSB=16
+    -DDEF_CMT_FCSB=18
+    -DDEF_CMT_IRQ=33
+    -DDEF_CMT_SDIO=35
+    -DDEF_CMT_SCLK=37
     -DLANG_DE
 monitor_filters =
     esp32_exception_decoder
@@ -224,6 +234,11 @@ build_flags = ${env.build_flags}
     -DDEF_NRF_MISO_PIN=3
     -DDEF_NRF_MOSI_PIN=4
     -DDEF_NRF_SCLK_PIN=2
+    -DDEF_CMT_CSB=255
+    -DDEF_CMT_FCSB=255
+    -DDEF_CMT_IRQ=255
+    -DDEF_CMT_SDIO=255
+    -DDEF_CMT_SCLK=255
 monitor_filters =
     esp32_exception_decoder
 
@@ -238,6 +253,11 @@ build_flags = ${env.build_flags}
     -DDEF_NRF_MISO_PIN=3
     -DDEF_NRF_MOSI_PIN=4
     -DDEF_NRF_SCLK_PIN=2
+    -DDEF_CMT_CSB=255
+    -DDEF_CMT_FCSB=255
+    -DDEF_CMT_IRQ=255
+    -DDEF_CMT_SDIO=255
+    -DDEF_CMT_SCLK=255
     -DLANG_DE
 monitor_filters =
     esp32_exception_decoder

--- a/src/web/html/setup.html
+++ b/src/web/html/setup.html
@@ -387,7 +387,7 @@
                 [36, "VP (GPIO36, {#PIN_INPUT_ONLY})"],
                 [39, "VN (GPIO39, {#PIN_INPUT_ONLY})"]
             ];
-            var esp32s3pins = [
+            var esp32sXpins = [
                 [255, "off / default"],
                 [0,  "GPIO0 ({#PIN_DONT_USE} - BOOT)"],
                 [1,  "GPIO1"],
@@ -418,8 +418,8 @@
                 [30, "GPIO30 (FLASH - {#PIN_NOT_AVAIL})"],
                 [31, "GPIO31 (FLASH - {#PIN_NOT_AVAIL})"],
                 [32, "GPIO32 (FLASH - {#PIN_NOT_AVAIL})"],
-                [33, "GPIO33 (not exposed on WROOM modules)"],
-                [34, "GPIO34 (not exposed on WROOM modules)"],
+                [33, "GPIO33 (not exposed on S3-WROOM modules)"],
+                [34, "GPIO34 (not exposed on S3-WROOM modules)"],
                 [35, "GPIO35"],
                 [36, "GPIO36"],
                 [37, "GPIO37"],
@@ -902,7 +902,7 @@
                 var pinList = esp8266pins;
                 /*IF_ESP32*/
                 var pinList = esp32pins;
-                if ("ESP32-S3" == system.chip_model) pinList = esp32s3pins;
+                if ("ESP32-S3" == system.chip_model || "ESP32-S2" == system.chip_model) pinList = esp32sXpins;
                 else if("ESP32-C3" == system["chip_model"]) pinList = esp32c3pins;
                 /*ENDIF_ESP32*/
                 pins = [['led0', 'pinLed0', '{#LED_AT_LEAST_ONE_PRODUCING}'], ['led1', 'pinLed1', '{#LED_MQTT_CONNECTED}'], ['led2', 'pinLed2', '{#LED_NIGHT_TIME}']];
@@ -938,7 +938,7 @@
                 var pinList = esp8266pins;
                 /*IF_ESP32*/
                 var pinList = esp32pins;
-                if ("ESP32-S3" == system.chip_model) pinList = esp32s3pins;
+                if ("ESP32-S3" == system.chip_model || "ESP32-S2" == system.chip_model) pinList = esp32sXpins;
                 else if("ESP32-C3" == system["chip_model"]) pinList = esp32c3pins;
                 /*ENDIF_ESP32*/
 
@@ -971,7 +971,7 @@
                 var e = document.getElementById("cmt");
                 var en = inp("cmtEnable", null, null, ["cb"], "cmtEnable", "checkbox");
                 var pinList = esp32pins;
-                if ("ESP32-S3" == system["chip_model"]) pinList = esp32s3pins;
+                if ("ESP32-S3" == system.chip_model || "ESP32-S2" == system.chip_model) pinList = esp32sXpins;
                 else if("ESP32-C3" == system["chip_model"]) pinList = esp32c3pins;
 
                 en.checked = obj["en"];
@@ -1005,7 +1005,7 @@
                 var pinList = esp8266pins;
                 /*IF_ESP32*/
                 var pinList = esp32pins;
-                if ("ESP32-S3" == system.chip_model) pinList = esp32s3pins;
+                if ("ESP32-S3" == system.chip_model || "ESP32-S2" == system.chip_model) pinList = esp32sXpins;
                 else if("ESP32-C3" == system["chip_model"]) pinList = esp32c3pins;
                 /*ENDIF_ESP32*/
 


### PR DESCRIPTION
Added better pin selection for S2 (mini) and improved default pins for S2 and C3.

I re-used the S3 Pin list, since it's the same as on the S2. The mini board dos not expose all of them. 
I thougt that doesn't need an indication, since there might be other boards around with more pins exposed.

I noticed that 2 different methods are used to access the board type. Once as `system.chip_model` and one as `system["chip_model"]` Don't know how this happened and which one is better. So I left it for others to decide.

