### PR TITLE
display graph 

### DIFF
--- a/src/plugins/Display/Display_Mono.h
+++ b/src/plugins/Display/Display_Mono.h
@@ -119,7 +119,7 @@ class DisplayMono {
                 case DispSwitchState::TEXT:
                     if (mDispSwitchTime.isTimeout()) {
                         mDispSwitchState = DispSwitchState::GRAPH;
-                        mDispSwitchTime.startTimeMonitor(150 * mCfg->graph_ratio);  // mGraphRatio: 0-100 Gesamtperiode 15000 ms
+                        mDispSwitchTime.startTimeMonitor(150 * mCfg->graph_ratio);  // graph_ratio: 0-100 Gesamtperiode 15000 ms
                         change = true;
                     }
                     break;
@@ -135,6 +135,7 @@ class DisplayMono {
         }
 
         void initPowerGraph(uint8_t width, uint8_t height) {
+            DBGPRINTLN("---- Init Power Graph ----");
             mPgWidth = width;
             mPgHeight = height;
             mPgData = new float[mPgWidth];
@@ -205,6 +206,10 @@ class DisplayMono {
             mDisplay->drawLine(xoff, yoff, xoff,            yoff - mPgHeight);  // vertical axis
             mDisplay->drawLine(xoff, yoff, xoff + mPgWidth, yoff);              // horizontal axis
 
+            // do not draw as long as time is not set correctly and no data was received
+            if ((mDisplayData->pGraphStartTime == 0) || (mDisplayData->pGraphEndTime == 0) || (mDisplayData->utcTs < 1) || (mPgMaxPwr < 1) || (mPgLastPos < 1))
+                return;
+
             // draw X scale
             tmElements_t tm;
             breakTime(mDisplayData->pGraphEndTime, tm);
@@ -234,7 +239,7 @@ class DisplayMono {
             // draw curve
             for (uint8_t i = 1; i <= mPgLastPos; i++) {
                 mDisplay->drawLine(xoff + getPowerGraphXpos(i - 1), yoff - getPowerGraphYpos(i - 1),
-                                         xoff + getPowerGraphXpos(i),     yoff - getPowerGraphYpos(i));
+                                   xoff + getPowerGraphXpos(i),     yoff - getPowerGraphYpos(i));
             }
 
             // print max power value

--- a/src/plugins/Display/Display_Mono_128X64.h
+++ b/src/plugins/Display/Display_Mono_128X64.h
@@ -58,7 +58,8 @@ class DisplayMono128X64 : public DisplayMono {
 
             widthShrink = (mCfg->screenSaver == 1) ? pixelShiftRange : 0;  // shrink graphwidth for pixelshift screensaver
 
-            initPowerGraph(mDispWidth - 22 - widthShrink, mLineYOffsets[graph_last_line] - mLineYOffsets[graph_first_line - 1] - 2);
+            if (mCfg->graph_ratio > 0)
+                initPowerGraph(mDispWidth - 22 - widthShrink, mLineYOffsets[graph_last_line] - mLineYOffsets[graph_first_line - 1] - 2);
 
             printText("Ahoy!", l_Ahoy, 0xff);
             printText("ahoydtu.de", l_Website, 0xff);
@@ -172,7 +173,7 @@ class DisplayMono128X64 : public DisplayMono {
                 printText(mFmtText, l_YieldTotal, 0xff);
             }
 
-            if (mDispSwitchState == DispSwitchState::GRAPH) {
+            if ((mCfg->graph_ratio > 0) && (mDispSwitchState == DispSwitchState::GRAPH)) {
                 // plot power graph
                 plotPowerGraph((mDispWidth - mPgWidth) / 2 + mPixelshift, mLineYOffsets[graph_last_line] - 1);
             }

--- a/src/plugins/Display/Display_Mono_84X48.h
+++ b/src/plugins/Display/Display_Mono_84X48.h
@@ -46,7 +46,8 @@ class DisplayMono84X48 : public DisplayMono {
                     break;
             }
 
-            initPowerGraph(mDispWidth - 16, mLineYOffsets[graph_last_line] - mLineYOffsets[graph_first_line - 1] - 2);
+            if (mCfg->graph_ratio > 0)
+                initPowerGraph(mDispWidth - 16, mLineYOffsets[graph_last_line] - mLineYOffsets[graph_first_line - 1] - 2);
 
             printText("Ahoy!", l_Ahoy, 0xff);
             printText("ahoydtu.de", l_Website, 0xff);
@@ -134,7 +135,7 @@ class DisplayMono84X48 : public DisplayMono {
                 printText(mFmtText, l_YieldTotal, 0xff);
             }
 
-            if (mDispSwitchState == DispSwitchState::GRAPH) {
+            if ((mCfg->graph_ratio > 0) && (mDispSwitchState == DispSwitchState::GRAPH)) {
                 // plot power graph
                 plotPowerGraph(8, mLineYOffsets[graph_last_line] - 1);
             }


### PR DESCRIPTION
Ich bin nicht sicher, ob es mit #1345 zu tun hat, weil ich den Fehler bei mir nicht nachstellen kann.
Ich habe aber ein paar Sicherheitsmaßnahmen zum display graph dazugebaut, damit in ein paar Sonderfällem (utc noch nicht sychronsiert...) nichts passieren kann.

Außerdem eine zusätzliche Debugausgabe beim Hochlauf, die an dieser Stelle bei der Initialisierung des Powergraph ausgegeben wird:
connect to network ...
I: added inverter ...
---- Init Power Graph ----
scanning APs with ...
BSSID ...

Vielleicht hilft das, den Fehler einzugrenzen.