### PR TITLE
ETH support for CMT2300A - HMS/HMT

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -93,6 +93,16 @@
         #define DEF_NRF_SCLK_PIN        18
     #endif
 
+#if defined(ETHERNET)
+    #ifndef DEF_CMT_SPI_HOST
+        #define DEF_CMT_SPI_HOST        SPI3_HOST
+    #endif
+#else
+    #ifndef DEF_CMT_SPI_HOST
+        #define DEF_CMT_SPI_HOST        SPI2_HOST
+    #endif
+#endif /* defined(ETHERNET) */
+
     #ifndef DEF_CMT_SCLK
         #define DEF_CMT_SCLK            12
     #endif

--- a/src/hms/cmtHal.h
+++ b/src/hms/cmtHal.h
@@ -17,7 +17,7 @@
 class cmtHal : public SpiPatcherHandle {
     public:
         cmtHal() {
-            mSpiPatcher = SpiPatcher::getInstance(SPI2_HOST);
+            mSpiPatcher = SpiPatcher::getInstance(DEF_CMT_SPI_HOST);
         }
 
         void patch() override {

--- a/src/hms/esp32_3wSpi.h
+++ b/src/hms/esp32_3wSpi.h
@@ -21,7 +21,7 @@
 // for ESP32 this is the so-called HSPI
 // for ESP32-S2/S3/C3 this nomenclature does not really exist anymore,
 // it is simply the first externally usable hardware SPI master controller
-#define SPI_CMT SPI2_HOST
+//#define SPI_CMT SPI2_HOST
 
 class esp32_3wSpi {
     public:
@@ -54,8 +54,8 @@ class esp32_3wSpi {
                 .post_cb = NULL,
             };
 
-            ESP_ERROR_CHECK(spi_bus_initialize(SPI_CMT, &buscfg, SPI_DMA_DISABLED));
-            ESP_ERROR_CHECK(spi_bus_add_device(SPI_CMT, &devcfg, &spi_reg));
+            ESP_ERROR_CHECK(spi_bus_initialize(DEF_CMT_SPI_HOST, &buscfg, SPI_DMA_DISABLED));
+            ESP_ERROR_CHECK(spi_bus_add_device(DEF_CMT_SPI_HOST, &devcfg, &spi_reg));
 
             // FiFo
             spi_device_interface_config_t devcfg2 = {
@@ -72,9 +72,9 @@ class esp32_3wSpi {
                 .pre_cb = NULL,
                 .post_cb = NULL,
             };
-            ESP_ERROR_CHECK(spi_bus_add_device(SPI_CMT, &devcfg2, &spi_fifo));
+            ESP_ERROR_CHECK(spi_bus_add_device(DEF_CMT_SPI_HOST, &devcfg2, &spi_fifo));
 
-            esp_rom_gpio_connect_out_signal(pinSdio, spi_periph_signal[SPI_CMT].spid_out, true, false);
+            esp_rom_gpio_connect_out_signal(pinSdio, spi_periph_signal[DEF_CMT_SPI_HOST].spid_out, true, false);
             delay(100);
 
             //pinMode(pinGpio3, INPUT);


### PR DESCRIPTION
W5500 benutzt SPI2, CMT ebenso-> Konflikt
Also W5500(Ethernet) und (NRF24 ODER CMT2300A), beides zusammen funktioniert nicht weil der ESP32 nur 2 freie SPI Busse hat.