### PR TITLE
fix immediate clearing of display after sunset

### DIFF
--- a/src/plugins/Display/Display_Mono_128X64.h
+++ b/src/plugins/Display/Display_Mono_128X64.h
@@ -89,9 +89,8 @@ class DisplayMono128X64 : public DisplayMono {
             calcPixelShift(pixelShiftRange);
 
             // add new power data to power graph
-            if (mDisplayData->nrProducing > 0) {
+            if (mDisplayData->nrProducing > 0)
                 addPowerGraphEntry(mDisplayData->totalPower);
-            }
 
             // print Date and time
             if (0 != mDisplayData->utcTs)


### PR DESCRIPTION
Aufgrund der geänderten Aufrufzeit von calculateSunriseSunset blieb der DisplayGraph nicht mehr wie geplant am Abend stehen.
Mit dem PR sollte dies nun wieder ordentlich funktionieren.
Ist seit gestern Abend durchgelaufen und hat sich auch heute Abend richtig verhalten.
Review schadet aber natürlich nie ;)