### PR TITLE
Add Watchdog for ESP32

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -8,6 +8,9 @@
 
 #include <Arduino.h>
 #include <ArduinoJson.h>
+#if defined(ESP32)
+#include <esp_task_wdt.h>
+#endif
 
 #include "config/settings.h"
 #include "defines.h"

--- a/src/defines.h
+++ b/src/defines.h
@@ -13,11 +13,7 @@
 //-------------------------------------
 #define VERSION_MAJOR       0
 #define VERSION_MINOR       8
-<<<<<<< HEAD
-#define VERSION_PATCH       560001
-=======
 #define VERSION_PATCH       57
->>>>>>> f503516c9feba7a7cc6fb427954165ce05cd7746
 
 //-------------------------------------
 typedef struct {

--- a/src/defines.h
+++ b/src/defines.h
@@ -13,7 +13,7 @@
 //-------------------------------------
 #define VERSION_MAJOR       0
 #define VERSION_MINOR       8
-#define VERSION_PATCH       56
+#define VERSION_PATCH       560001
 
 //-------------------------------------
 typedef struct {


### PR DESCRIPTION
Watchdog für den ESP32 hinzugefügt, da er in einer Lib die nicht in den Minimal-Versionen enthalten ist verwendet wird und es so zu wdt Reboots kam.