### PR TITLE
fixed millis in serial log

### DIFF
--- a/src/app.h
+++ b/src/app.h
@@ -115,7 +115,7 @@ class app : public IApp, public ah::Scheduler {
         }
 
         uint64_t getTimestampMs() {
-            return ((uint64_t)Scheduler::mTimestamp * 1000) + (uint64_t)Scheduler::mTsMillis;
+            return ((uint64_t)Scheduler::mTimestamp * 1000) + ((uint64_t)millis() - (uint64_t)Scheduler::mTsMillis) % 1000;
         }
 
         bool saveSettings(bool reboot) {

--- a/src/utils/helper.cpp
+++ b/src/utils/helper.cpp
@@ -72,11 +72,13 @@ namespace ah {
 
     String getTimeStrMs(uint64_t t) {
         char str[13];
+        uint16_t m;
         if(0 == t)
             sprintf(str, "n/a");
         else {
-            t = (t + (millis() % 1000)) / 1000;
-            sprintf(str, "%02d:%02d:%02d.%03d", hour(t), minute(t), second(t), (uint16_t)(millis() % 1000));
+            m = t % 1000;
+            t = t / 1000;
+            sprintf(str, "%02d:%02d:%02d.%03d", hour(t), minute(t), second(t), m);
         }
         return String(str);
     }

--- a/src/utils/scheduler.h
+++ b/src/utils/scheduler.h
@@ -34,9 +34,9 @@ namespace ah {
             void setup(bool directStart) {
                 mUptime     = 0;
                 mTimestamp  = (directStart) ? 1 : 0;
-                mTsMillis   = 0;
                 mMax        = 0;
                 mPrevMillis = millis();
+                mTsMillis   = mPrevMillis % 1000;
                 resetTicker();
             }
 
@@ -62,7 +62,7 @@ namespace ah {
                 mUptime += mDiffSeconds;
                 if(0 != mTimestamp) {
                     mTimestamp += mDiffSeconds;
-                    mTsMillis  = mMillis % 1000;
+                    mTsMillis  = mPrevMillis % 1000;
                 }
                 checkTicker();
 
@@ -80,7 +80,6 @@ namespace ah {
 
             virtual void setTimestamp(uint32_t ts) {
                 mTimestamp = ts;
-                mTsMillis  = millis() % 1000;
             }
 
             bool resetEveryById(uint8_t id) {


### PR DESCRIPTION
Dieser PR behebt einen Fehler in der Anzeige des Zeitstempels in der Web Konsole, bei dem der Überlauf der Millisekunden nicht zum Anfang einer neuen Sekunde erfolgt.

> 20:44:06.918 I: MQTT got topic: inverter/ctrl/limit/0
20:44:06.098 I: (#0) sendControlPacket cmd: 0b
20:44:06.171 I: (#0) RX  25ms | 17 CH61 | d1 81
20:44:06.172 I: (#0) has accepted power limit set point 30.00 with PowerLimitControl 0
20:44:06.175 -----