### PR TITLE
provide localized times to display mono classes

### DIFF
--- a/src/plugins/Display/Display.h
+++ b/src/plugins/Display/Display.h
@@ -162,14 +162,15 @@ class Display {
         mDisplayData.RadioRSSI = ivQuality2RadioRSSI(minQAllInv); // Workaround as NRF24 has no RSSI. Approximation by quality levels from heuristic function
         mDisplayData.WifiRSSI = (WiFi.status() == WL_CONNECTED) ? WiFi.RSSI() : SCHAR_MIN;
         mDisplayData.ipAddress = WiFi.localIP();
+
+        // provide localized times to display classes
         time_t utc= mApp->getTimestamp();
         if (year(utc) > 2020)
-            mDisplayData.utcTs = utc;
+            mDisplayData.utcTs = gTimezone.toLocal(utc);
         else
             mDisplayData.utcTs = 0;
-
-        mDisplayData.pGraphStartTime = mApp->getSunrise();
-        mDisplayData.pGraphEndTime = mApp->getSunset();
+        mDisplayData.pGraphStartTime = gTimezone.toLocal(mApp->getSunrise());
+        mDisplayData.pGraphEndTime = gTimezone.toLocal(mApp->getSunset());
 
         if (mMono ) {
             mMono->disp();

--- a/src/plugins/Display/Display_Mono_128X32.h
+++ b/src/plugins/Display/Display_Mono_128X32.h
@@ -56,7 +56,7 @@ class DisplayMono128X32 : public DisplayMono {
                 snprintf(mFmtText, DISP_FMT_TEXT_LEN, "%d Inverter on", mDisplayData->nrProducing);
                 printText(mFmtText, 3);
             } else if (0 != mDisplayData->utcTs)
-                printText(ah::getTimeStr(gTimezone.toLocal(mDisplayData->utcTs)).c_str(), 3);
+                printText(ah::getTimeStr(mDisplayData->utcTs).c_str(), 3);
 
             mDisplay->sendBuffer();
 

--- a/src/plugins/Display/Display_Mono_128X64.h
+++ b/src/plugins/Display/Display_Mono_128X64.h
@@ -95,7 +95,7 @@ class DisplayMono128X64 : public DisplayMono {
 
             // print Date and time
             if (0 != mDisplayData->utcTs)
-                printText(ah::getDateTimeStrShort(gTimezone.toLocal(mDisplayData->utcTs)).c_str(), l_Time, 0xff);
+                printText(ah::getDateTimeStrShort(mDisplayData->utcTs).c_str(), l_Time, 0xff);
 
             if (showLine(l_Status)) {
                 // alternatively:

--- a/src/plugins/Display/Display_Mono_64X48.h
+++ b/src/plugins/Display/Display_Mono_64X48.h
@@ -58,7 +58,7 @@ class DisplayMono64X48 : public DisplayMono {
                 snprintf(mFmtText, DISP_FMT_TEXT_LEN, "active Inv: %d", mDisplayData->nrProducing);
                 printText(mFmtText, 3);
             } else if (0 != mDisplayData->utcTs)
-                printText(ah::getTimeStr(gTimezone.toLocal(mDisplayData->utcTs)).c_str(), 3);
+                printText(ah::getTimeStr(mDisplayData->utcTs).c_str(), 3);
 
             mDisplay->sendBuffer();
 

--- a/src/plugins/Display/Display_Mono_84X48.h
+++ b/src/plugins/Display/Display_Mono_84X48.h
@@ -78,7 +78,7 @@ class DisplayMono84X48 : public DisplayMono {
 
             // print Date and time
             if (0 != mDisplayData->utcTs)
-                printText(ah::getDateTimeStrShort(gTimezone.toLocal(mDisplayData->utcTs)).c_str(), l_Time, 0xff);
+                printText(ah::getDateTimeStrShort(mDisplayData->utcTs).c_str(), l_Time, 0xff);
 
             if (showLine(l_Status)) {
                 // alternatively:

--- a/src/plugins/Display/Display_data.h
+++ b/src/plugins/Display/Display_data.h
@@ -8,9 +8,9 @@ struct DisplayData {
     float totalPower=0.0f;      // indicate current power (W)
     float totalYieldDay=0.0f;   // indicate day yield (Wh)
     float totalYieldTotal=0.0f; // indicate total yield (kWh)
-    uint32_t utcTs=0;           // indicate absolute timestamp (utc unix time). 0 = time is not synchonized
-    uint32_t pGraphStartTime=0; // starttime for power graph (e.g. sunRise)
-    uint32_t pGraphEndTime=0;   // starttime for power graph (e.g. sunSet)
+    uint32_t utcTs=0;           // indicate absolute timestamp (localized utc unix time). 0 = time is not synchonized
+    uint32_t pGraphStartTime=0; // localized starttime for power graph (e.g. sunRise)
+    uint32_t pGraphEndTime=0;   // localized endttime for power graph (e.g. sunSet)
     uint8_t nrProducing=0;      // indicate number of producing inverters
     uint8_t nrSleeping=0;       // indicate number of sleeping inverters
     bool WifiSymbol = false;    // indicate if WiFi is connected


### PR DESCRIPTION
Mist, jetzt war ich ein paar Minuten zu spät mit meiner 'last minute' Änderung! 
Leider ist mir erst zu Mittag aufgefallen, dass die neue 12h Markierung die ich bei #1374 zum display graph hinzugefügt habe, um 1 Std versetzt ist (aufgrund der Zeitzone).
Hätte nicht gedacht, dass es heute Mittag schon eine neue Version gibt! ;-) 
Na gut, jetzt sind halt einen Tag lang ein paar Pixel falsch gesetzt ...

Ich füttere jetzt die Display Mono Klassen nur noch mit lokalisierten Zeiten, sonst muss man die Zeitzone darin immer berücksichtigen.