### PR TITLE
Add some REST Api Endpoints to avail_endpoints

### DIFF
--- a/src/web/RestApi.h
+++ b/src/web/RestApi.h
@@ -200,8 +200,14 @@ class RestApi {
             ep[F("generic")]          = url + F("generic");
             ep[F("index")]            = url + F("index");
             ep[F("setup")]            = url + F("setup");
+            #if !defined(ETHERNET)
+            ep[F("setup/networks")]   = url + F("setup/networks");
+            ep[F("setup/getip")]      = url + F("setup/getip");
+            #endif /* !defined(ETHERNET) */
             ep[F("system")]           = url + F("system");
             ep[F("live")]             = url + F("live");
+            ep[F("powerHistory")]     = url + F("powerHistory");
+            ep[F("yieldDayHistory")]  = url + F("yieldDayHistory");
         }
 
 


### PR DESCRIPTION
Die REST Api Endpoints

```
setup/networks	"http://ahoy-dtu2.local/api/setup/networks"
setup/getip	"http://ahoy-dtu2.local/api/setup/getip"
powerHistory	"http://ahoy-dtu2.local/api/powerHistory"
yieldDayHistory	"http://ahoy-dtu2.local/api/yieldDayHistory"
```
waren in der Übersicht der verfügbaren Endpoints nicht gelistet.

Werden hiermit hinzugefügt.

Wenn's gefällt, bitte übernehmen.