### PR TITLE
ETH NTP update bugfix

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -172,7 +172,6 @@ void app::onNetwork(bool gotIp) {
     mMqttReconnect = true;
     mSunrise = 0;  // needs to be set to 0, to reinstall sunrise and ivComm tickers!
     once(std::bind(&app::tickNtpUpdate, this), 2, "ntp2");
-    //tickNtpUpdate();
     #if !defined(ETHERNET)
     if (WIFI_AP == WiFi.getMode()) {
         mMqttEnabled = false;
@@ -206,12 +205,7 @@ void app::regularTickers(void) {
 
 #if defined(ETHERNET)
 void app::onNtpUpdate(bool gotTime) {
-    uint32_t nxtTrig = 5;  // default: check again in 5 sec
-    if (gotTime || mTimestamp != 0) {
-        this->updateNtp();
-        nxtTrig = gotTime ? 43200 : 60;  // depending on NTP update success check again in 12 h or in 1 min
-    }
-    once(std::bind(&app::tickNtpUpdate, this), nxtTrig, "ntp");
+    mNtpReceived = true;
 }
 #endif /* defined(ETHERNET) */
 
@@ -255,13 +249,22 @@ void app::updateNtp(void) {
 //-----------------------------------------------------------------------------
 void app::tickNtpUpdate(void) {
     uint32_t nxtTrig = 5;  // default: check again in 5 sec
+    bool isOK = false;
+
     #if defined(ETHERNET)
-    bool isOK = (mTimestamp != 0);
-    mEth.updateNtpTime();
+    if (!mNtpReceived)
+    {
+        mEth.updateNtpTime();
+    }
+    else
+    {
+        mNtpReceived = false;
+        isOK = true;
+    }
     #else
-    bool isOK = mWifi.getNtpTime();
+    isOK = mWifi.getNtpTime();
     #endif
-    if (isOK || mTimestamp != 0) {
+    if (isOK) {
         this->updateNtp();
 
         nxtTrig = isOK ? (mConfig->ntp.interval * 60) : 60;  // depending on NTP update success check again in 12h (depends on setting) or in 1 min
@@ -565,6 +568,10 @@ void app::resetSystem(void) {
     mSaveReboot = false;
 
     mNetworkConnected = false;
+
+#if defined(ETHERNET)
+    mNtpReceived = false;
+#endif
 }
 
 //-----------------------------------------------------------------------------

--- a/src/app.h
+++ b/src/app.h
@@ -351,6 +351,7 @@ class app : public IApp, public ah::Scheduler {
         void tickNtpUpdate(void);
         #if defined(ETHERNET)
         void onNtpUpdate(bool gotTime);
+        bool mNtpReceived;
         #endif /* defined(ETHERNET) */
         void updateNtp(void);
 


### PR DESCRIPTION
Fixx für https://github.com/lumapu/ahoy/issues/886#issuecomment-1902173420

Jetzt zieht er sich beim starten auch nur noch 1x die Zeit, funktioniert auch bei Trennung des Kabels.
Falls NTP Server nicht erreichbar probiert er es alle 5 sec.