### PR TITLE
Add hint to INV_RESET_MIDNIGHT resp. INV_PAUSE_DURING_NIGHT

### DIFF
--- a/src/web/lang.json
+++ b/src/web/lang.json
@@ -290,8 +290,8 @@
                 },
                 {
                     "token": "INV_RESET_MIDNIGHT",
-                    "en": "Reset values and YieldDay at midnight",
-                    "de": "Werte und Gesamtertrag um Mitternacht zur&uuml;cksetzen"
+                    "en": "Reset values and YieldDay at midnight. ('Pause communication during night' need to be set)",
+                    "de": "Werte und Gesamtertrag um Mitternacht zur&uuml;cksetzen ('Kommunikation w&auml;hrend der Nacht pausieren' muss gesetzt sein)"
                 },
                 {
                     "token": "INV_PAUSE_SUNSET",


### PR DESCRIPTION
Bezüglich #1350 habe für den Nutzer einen kleinen Hinweis von `Reset values and YieldDay at midnight` auf `Pause communication during night` gemacht. 

Würde dann so aussehen:
![en](https://github.com/lumapu/ahoy/assets/58307481/34c3d706-cca9-4374-b29e-79700f95c60e)

![de](https://github.com/lumapu/ahoy/assets/58307481/b699aae1-deec-4f5c-8b93-ea3d28768045)

Vielleicht gefällt es dir und vielleicht hilft es auch die eine oder andere Rückfrage zu verhindern.