### PR TITLE
Remove hint to INV_RESET_MIDNIGHT resp. INV_PAUSE_DURING_NIGHT

### DIFF
--- a/src/web/lang.json
+++ b/src/web/lang.json
@@ -295,8 +295,8 @@
                 },
                 {
                     "token": "INV_RESET_MIDNIGHT",
-                    "en": "Reset values and YieldDay at midnight. ('Pause communication during night' need to be set)",
-                    "de": "Werte und Gesamtertrag um Mitternacht zur&uuml;cksetzen ('Kommunikation w&auml;hrend der Nacht pausieren' muss gesetzt sein)"
+                    "en": "Reset values and YieldDay at midnight",
+                    "de": "Werte und Gesamtertrag um Mitternacht zur&uuml;cksetzen"
                 },
                 {
                     "token": "INV_PAUSE_SUNSET",


### PR DESCRIPTION
Den kleinen Hinweis von `Reset values and YieldDay at midnight` auf `Pause communication during night` wird entfernt.
Aufräumarbeiten zu #1429 und #1350 