### PR TITLE
Catch wrong datatype on POST to REST-API (/api/ctrl)

### DIFF
--- a/src/web/lang.h
+++ b/src/web/lang.h
@@ -43,6 +43,12 @@
 #endif
 
 #ifdef LANG_DE
+    #define INVALID_DATATYPE "Ungültiger Datentyp"
+#else /*LANG_EN*/
+    #define INVALID_DATATYPE "Invalid datatype"
+#endif
+
+#ifdef LANG_DE
     #define NOT_ENOUGH_MEM "nicht genügend Speicher"
 #else /*LANG_EN*/
     #define NOT_ENOUGH_MEM "Not enough memory"


### PR DESCRIPTION
Using an incorrect datatype (e.g. an array) when POSTing to the REST API under /api/ctrl leads to a reboot (at least one sample found in the internet show this incorrect structure and the error is hard to see).

This commit checks if the incoming body is indeed a JsonObject and adds an additional error message (DE and EN).