### PR TITLE
shorten last cmt waiting time

### DIFF
--- a/src/hms/hmsRadio.h
+++ b/src/hms/hmsRadio.h
@@ -183,7 +183,7 @@ class CmtRadio : public Radio {
 
             if(p.packet[9] > ALL_FRAMES) { // indicates last frame
                 setExpectedFrames(p.packet[9] - ALL_FRAMES);
-                mRadioWaitTime.startTimeMonitor(DURATION_PAUSE_LASTFR); // let the inverter first get back to rx mode?
+                mRadioWaitTime.startTimeMonitor(2); // let the inverter first get back to rx mode?
             }
         }
 


### PR DESCRIPTION
after last frame is received. Works, see around this discord post: https://discord.com/channels/984173303147155506/1029761098381017098/1220679912587792404 (was also with 2 ms, most likely also 0 ms would work).