### PR TITLE
switch to new MQTTClient version

### DIFF
--- a/src/platformio.ini
+++ b/src/platformio.ini
@@ -29,7 +29,7 @@ lib_deps =
     https://github.com/esphome/ESPAsyncWebServer @ ^3.2.0
     https://github.com/nRF24/RF24.git#v1.4.8
     paulstoffregen/Time @ ^1.6.1
-    https://github.com/bertmelis/espMqttClient#v1.6.0
+    https://github.com/bertmelis/espMqttClient#v1.7.0
     bblanchon/ArduinoJson @ ^6.21.3
     https://github.com/JChristensen/Timezone @ ^1.2.4
     olikraus/U8g2 @ ^2.35.9


### PR DESCRIPTION
Bugfixes and new features
https://github.com/bertmelis/espMqttClient/releases/tag/v1.7.0

https://github.com/bertmelis/espMqttClient/issues/153

    Fixed a connection that could get stuck during connecting
    Fixed memory corruption on high loads
    Experimental feature: a memory pool: be sure to read the section in the docs on #define EMC_USE_MEMPOOL.
    Also: explicit dependencies are removed. While this breaks auto dependency management in various IDEs, the feature caused problems with multiple flavours of the dependency. I decided to just remove it completely. So yes, you will probably need to manually define the dependencies.
