### PR TITLE
reduce update cycle of ePaper from 5 to 10 seconds

### DIFF
--- a/src/plugins/Display/Display.h
+++ b/src/plugins/Display/Display.h
@@ -79,16 +79,25 @@ class Display {
         void tickerSecond() {
             bool request_refresh = false;
 
-            if (mMono != NULL)
+            if (mMono != NULL) {
+                // maintain LCD and OLED displays with pixel shift screensavers, at least every 5 seconds
                 request_refresh = mMono->loop(motionSensorActive());
-
-            if (mNewPayload || (((++mLoopCnt) % 5) == 0) || request_refresh) {
-                DataScreen();
-                mNewPayload = false;
-                mLoopCnt = 0;
-            }
+                if (mNewPayload || (((++mLoopCnt) % 5) == 0) || request_refresh) {
+                    DataScreen();
+                    mNewPayload = false;
+                    mLoopCnt = 0;
+                }
+            }    
             #if defined(ESP32) && !defined(ETHERNET)
+            else if (DISP_TYPE_T10_EPAPER == mCfg->type) {
+                // maintain ePaper at least every 10 seconds
+                if (mNewPayload || (((++mLoopCnt) % 10) == 0)) {
+                    DataScreen();
+                    mNewPayload = false;
+                    mLoopCnt = 0;
+                }
                 mEpaper.tickerSecond();
+            }
             #endif
         }
 
@@ -180,12 +189,14 @@ class Display {
             else if (DISP_TYPE_T10_EPAPER == mCfg->type) {
                 mEpaper.loop((totalPower), totalYieldDay, totalYieldTotal, nrprod);
                 mRefreshCycle++;
+
+                if (mRefreshCycle > 480) {
+                    mEpaper.fullRefresh();
+                    mRefreshCycle = 0;
+                }
+
             }
 
-            if (mRefreshCycle > 480) {
-                mEpaper.fullRefresh();
-                mRefreshCycle = 0;
-            }
     #endif
         }
 


### PR DESCRIPTION
Hi,
ich habe ja damals die Änderungen für die OLED Displays (screensaver, symbols...) gemacht, wollte aber eigentlich das ePaper gar nicht angreifen, da ich selbst keines zum Testen habe. Wie ich nun sehe (#1107), gab es aber offenbar einen kleinen Nebeneffekt auf das ePaper, indem der FullRefresh nun alle 480 x 5 Sekunden, anstatt wie vorher alle 480 x 10 Sekunden durchgeführt wird. 

Ich kann mir das Fehlverhalten des ePaper Refresh rein vom Lesen des Sourcecodes zwar nicht wirklich erklären, zumal nämlich auch vorher schon bei neuen Inverter-Daten (mNewPayload) zusätzliche, azyklische ePaper refreshs durchgeführt wurden. Außerdem hatte Knickohr ja die Ghostings schon mit "0.7.38 und davor" gemeldet, also lange vor meinen OLED-Änderungen. Andererseits sind aber die sehr guten Tests von Lötnase (#1107) nicht von der Hand zu weisen, das sieht eindeutig nach etwas Systematischem aus.

Ich hätte hier daher einmal einen Vorschlag für einen Fix, um die Wartung der im Timing doch recht unterschiedlichen OLED und ePaper Displays besser zu trennen, und wieder die ursprüngliche 10s Taktung des ePapers herzustellen. Ob die ePaper Phänomene damit komplett verschwinden würde ich bezweifeln, aber vielleicht treten sie damit wieder seltener auf.

Ein kleiner zusätzlicher Bugfix ist auch mit dabei (mEpaper.tickerSecond() und mEpaper.fullRefresh() wurden immer aufgerufen, auch wenn kein ePaper konfiguriert und initialisiert war, welche Auswirkungen immer das auch hatte...)

Bitte um Review (@lumapu) und Tests durch die ePaper Besitzer!