### PR TITLE
[re-open] add read_temp_c to system + mqtt

### DIFF
--- a/src/publisher/pubMqtt.h
+++ b/src/publisher/pubMqtt.h
@@ -158,6 +158,7 @@ class PubMqtt {
             publish(subtopics[MQTT_UPTIME], mVal.data());
             publish(subtopics[MQTT_RSSI], String(WiFi.RSSI()).c_str());
             publish(subtopics[MQTT_FREE_HEAP], String(ESP.getFreeHeap()).c_str());
+            publish(subtopics[MQTT_TEMP_SENS_C], String(ah::readTemperature()).c_str());
             #ifndef ESP32
             publish(subtopics[MQTT_HEAP_FRAG], String(ESP.getHeapFragmentation()).c_str());
             #endif

--- a/src/publisher/pubMqttDefs.h
+++ b/src/publisher/pubMqttDefs.h
@@ -56,7 +56,8 @@ enum {
     MQTT_STATUS,
     MQTT_LWT_ONLINE,
     MQTT_LWT_OFFLINE,
-    MQTT_ACK_PWR_LMT
+    MQTT_ACK_PWR_LMT,
+    MQTT_TEMP_SENS_C
 };
 
 const char* const subtopics[] PROGMEM = {
@@ -76,7 +77,8 @@ const char* const subtopics[] PROGMEM = {
     "status",
     "connected",
     "not_connected",
-    "ack_pwr_limit"
+    "ack_pwr_limit",
+    "temp_sensor_c"
 };
 
 enum {

--- a/src/utils/helper.cpp
+++ b/src/utils/helper.cpp
@@ -3,6 +3,7 @@
 // Creative Commons - http://creativecommons.org/licenses/by-nc-sa/3.0/de/
 //-----------------------------------------------------------------------------
 
+#include <Arduino.h>
 #include "helper.h"
 #include "dbg.h"
 #include "../plugins/plugin_lang.h"
@@ -142,4 +143,22 @@ namespace ah {
         }
         DBGPRINTLN("");
     }
+
+#if defined(ESP32)
+    float readTemperature() {
+        /*// ADC1 channel 0 is GPIO36
+        adc1_config_width(ADC_WIDTH_BIT_12);
+        adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_DB_0);
+        int adc_reading = adc1_get_raw(ADC1_CHANNEL_0);
+        // Convert the raw ADC reading to a voltage in mV
+        esp_adc_cal_characteristics_t characteristics;
+        esp_adc_cal_value_t val_type = esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_0, ADC_WIDTH_BIT_12, 1100, &characteristics);
+        uint32_t voltage = esp_adc_cal_raw_to_voltage(adc_reading, &characteristics);
+        // Convert the voltage to a temperature in Celsius
+        // This formula is an approximation and might need to be calibrated for your specific use case.
+        float temperature = (voltage - 500) / 10.0;*/
+
+        return temperatureRead();
+    }
+#endif
 }

--- a/src/utils/helper.h
+++ b/src/utils/helper.h
@@ -49,6 +49,10 @@ namespace ah {
     String getTimeStrMs(uint64_t t);
     uint64_t Serial2u64(const char *val);
     void dumpBuf(uint8_t buf[], uint8_t len, uint8_t firstRepl = 0, uint8_t lastRepl = 0);
+
+    #if defined(ESP32)
+    float readTemperature();
+    #endif
 }
 
 #endif /*__HELPER_H__*/

--- a/src/web/RestApi.h
+++ b/src/web/RestApi.h
@@ -878,6 +878,8 @@ class RestApi {
             obj[F("par_size_app0")] = ESP.getFreeSketchSpace();
             obj[F("par_used_app0")] = ESP.getSketchSize();
 
+            obj[F("temp_sensor_c")] = ah::readTemperature();
+            
             #if defined(ESP32)
                 obj[F("heap_total")] = ESP.getHeapSize();
 

--- a/src/web/RestApi.h
+++ b/src/web/RestApi.h
@@ -822,6 +822,8 @@ class RestApi {
         void getChipInfo(JsonObject obj) {
             obj[F("cpu_freq")]     = ESP.getCpuFreqMHz();
             obj[F("sdk")]          = ESP.getSdkVersion();
+            obj[F("temp_sensor_c")] = ah::readTemperature();
+
             #if defined(ESP32)
                 obj[F("revision")] = ESP.getChipRevision();
                 obj[F("model")]    = ESP.getChipModel();
@@ -878,8 +880,6 @@ class RestApi {
             obj[F("par_size_app0")] = ESP.getFreeSketchSpace();
             obj[F("par_used_app0")] = ESP.getSketchSize();
 
-            obj[F("temp_sensor_c")] = ah::readTemperature();
-            
             #if defined(ESP32)
                 obj[F("heap_total")] = ESP.getHeapSize();
 

--- a/src/web/html/system.html
+++ b/src/web/html/system.html
@@ -44,7 +44,8 @@
                     tr("{#ENVIRONMENT}", obj.generic.env + " ({#BUILD_OPTIONS}: " + obj.generic.modules + ")"),
                     tr("Version", obj.generic.version + " - " + obj.generic.build),
                     tr("Chip", "CPU: " + obj.chip.cpu_freq + "MHz, " + obj.chip.cores + " Core(s)"),
-                    tr("Chip Model", obj.chip.model)
+                    tr("Chip Model", obj.chip.model),
+                    tr("Chip temp.", obj.chip.temp_sensor_c),
                 ]
 
                 document.getElementById("info").append(

--- a/src/web/html/system.html
+++ b/src/web/html/system.html
@@ -45,7 +45,7 @@
                     tr("Version", obj.generic.version + " - " + obj.generic.build),
                     tr("Chip", "CPU: " + obj.chip.cpu_freq + "MHz, " + obj.chip.cores + " Core(s)"),
                     tr("Chip Model", obj.chip.model),
-                    tr("Chip temp.", obj.chip.temp_sensor_c),
+                    tr("Chip temp.", obj.chip.temp_sensor_c + "&deg;C"),
                 ]
 
                 document.getElementById("info").append(


### PR DESCRIPTION
Now it is possible to read the temp from the ESP32 Core.
Please take care of ESP8266, because that is not possible?

See function "readTemperature()", it is written for the Arduino-Lib. But it is prepared for the ESP-IDF.

The data is now in the /system, mqtt and in the API available.

Cheers. :)
