### PR TITLE
Fix: Ensure LWT (Last Will and Testament) messages are always retained

### DIFF
--- a/src/publisher/pubMqtt.h
+++ b/src/publisher/pubMqtt.h
@@ -235,7 +235,7 @@ class PubMqtt {
             else
                 snprintf(mTopic.data(), mTopic.size(), "%s", subTopic);
 
-            if(!mCfgMqtt->enableRetain)
+            if(!mCfgMqtt->enableRetain && String(mTopic.data()) != String(mLwtTopic.data()))
                 retained = false;
 
             mClient.publish(mTopic.data(), qos, retained, payload);

--- a/src/publisher/pubMqtt.h
+++ b/src/publisher/pubMqtt.h
@@ -235,8 +235,12 @@ class PubMqtt {
             else
                 snprintf(mTopic.data(), mTopic.size(), "%s", subTopic);
 
-            if(!mCfgMqtt->enableRetain && String(mTopic.data()) != String(mLwtTopic.data()))
+            if(!mCfgMqtt->enableRetain)
                 retained = false;
+
+            // LWT messages should always be retained
+            if(strcmp(mTopic.data(), mLwtTopic.data()) == 0)
+                retained = true;
 
             mClient.publish(mTopic.data(), qos, retained, payload);
             yield();


### PR DESCRIPTION
## Fix: Ensure LWT (Last Will and Testament) messages are always retained

### Problem
MQTT Last Will and Testament (LWT) messages are critical for indicating device connectivity status to MQTT clients and Home Assistant. These messages must be retained on the MQTT broker to ensure that clients connecting after a device disconnect can immediately see the device's offline status.

Currently, the global `enableRetain` setting in MQTT configuration affects all messages, including LWT messages. When users disable `enableRetain` to prevent sensor values from being retained, LWT messages are also not retained, causing connectivity status to be unreliable for clients that connect after a device goes offline.

### Solution
This PR modifies the `publish()` function in `pubMqtt.h` to ensure that LWT messages are always sent with `retained=true`, regardless of the global `enableRetain` setting. This guarantees proper MQTT connectivity monitoring while preserving user control over sensor data retention.

### Changes
- Modified `pubMqtt.h` to add LWT retain logic
- LWT messages are now force-retained even when `enableRetain` is disabled
- Preserves existing behavior for all other MQTT messages
- Uses efficient `strcmp()` for topic comparison

### Technical Details
The fix adds logic to detect when a message is being sent to the LWT topic and ensures it's always retained:

```cpp
if(!mCfgMqtt->enableRetain)
    retained = false;

// LWT messages should always be retained
if(strcmp(mTopic.data(), mLwtTopic.data()) == 0)
    retained = true;
```

### Testing
- LWT messages are now retained on MQTT broker even when `enableRetain` is disabled
- Device connectivity status is properly maintained for all MQTT clients
- Regular sensor data respects the `enableRetain` setting as before
- Offline/online status is immediately visible to clients connecting after device state changes

### Backward Compatibility
This change is fully backward compatible. Users who have `enableRetain` enabled will see no change in behavior. Users who have it disabled will now have reliable device connectivity monitoring without needing to enable retain for all messages.

Fixes MQTT device connectivity monitoring when `enableRetain` is disabled.

```
# Before (0.8.156)
$ mosquitto_sub -v -t '#' -F "%r %t %p"
1 ahoy-dtu/mqtt not connected
0 ahoy-dtu/uptime 1207
0 ahoy-dtu/wifi_rssi -71
0 ahoy-dtu/free_heap 13032
0 ahoy-dtu/heap_frag 9
$

# After
$ mosquitto_sub -v -t '#' -F "%r %t %p"
1 ahoy-dtu/mqtt connect
0 ahoy-dtu/uptime 1207
0 ahoy-dtu/wifi_rssi -71
0 ahoy-dtu/free_heap 13032
0 ahoy-dtu/heap_frag 9
$
