### PR TITLE
Fix: Ensure Home Assistant discovery messages are always retained

### DIFF
--- a/src/publisher/pubMqtt.h
+++ b/src/publisher/pubMqtt.h
@@ -238,6 +238,10 @@ class PubMqtt {
             if(!mCfgMqtt->enableRetain)
                 retained = false;
 
+            // Home Assistant requires retained discovery messages
+            if(strncmp(subTopic, MQTT_DISCOVERY_PREFIX, strlen(MQTT_DISCOVERY_PREFIX)) == 0)
+                retained = true;
+
             mClient.publish(mTopic.data(), qos, retained, payload);
             yield();
             mTxCnt++;


### PR DESCRIPTION
## Fix: Ensure Home Assistant discovery messages are always retained

### Problem
Home Assistant requires MQTT discovery messages to be sent with the `retained` flag set to `true` for proper device discovery. Currently, the global `enableRetain` setting in MQTT configuration affects all messages, including discovery messages. When users disable `enableRetain` to prevent sensor values from being retained, Home Assistant discovery stops working because discovery messages are no longer retained.

### Solution
This PR modifies the `publish()` function in `pubMqtt.h` to ensure that Home Assistant discovery messages (topics starting with `homeassistant/`) are always sent with `retained=true`, regardless of the global `enableRetain` setting.

### Changes
- Modified `pubMqtt.h` lines 238-243
- Added logic to force `retained=true` for discovery messages after the global retain check
- Preserves existing behavior for all other MQTT messages

### Testing
- Discovery messages are now retained on MQTT broker even when `enableRetain` is disabled
- Regular sensor data respects the `enableRetain` setting as before
- Home Assistant device discovery works regardless of retain configuration

### Backward Compatibility
This change is fully backward compatible. Users who have `enableRetain` enabled will see no change in behavior. Users who have it disabled will now have working Home Assistant discovery without needing to enable retain for all messages.

Fixes Home Assistant integration when `enableRetain` is disabled.