### PR TITLE
Add support for 1st Gen MI units

### DIFF
--- a/src/hm/NrfRadio.h
+++ b/src/hm/NrfRadio.h
@@ -86,7 +86,7 @@ class NrfRadio : public Radio {
             #endif
             mNrf24->setRetries(3, 15); // wait 3*250 = 750us, 16 * 250us -> 4000us = 4ms
 
-            mNrf24->setDataRate(RF24_250KBPS);
+            mNrf24->setDataRate(RF24_250KBPS); // Start at 250KBPS by default, only MI Gen1 uses 2MBPS
             //mNrf24->setAutoAck(true); // enabled by default
             //mNrf24->enableDynamicAck();
             mNrf24->enableDynamicPayloads();
@@ -360,6 +360,7 @@ class NrfRadio : public Radio {
 
         void sendPacket(Inverter<> *iv, uint8_t len, bool isRetransmit, bool appendCrc16=true) {
             mNrf24->setPALevel(iv->config->powerLevel & 0x03);
+            mNrf24->setDataRate(iv->radioDataRate);	// Change datarate for MI Gen1: uses 2MBPS
             updateCrcs(&len, appendCrc16);
 
             // set TX and RX channels

--- a/src/hm/hmInverter.h
+++ b/src/hm/hmInverter.h
@@ -23,6 +23,7 @@
 #include "../config/settings.h"
 
 #include "Radio.h"
+#include <RF24.h>
 /**
  * For values which are of interest and not transmitted by the inverter can be
  * calculated automatically.
@@ -126,6 +127,7 @@ class Inverter {
     public:
         uint8_t       ivGen = IV_UNKNOWN;                   // generation of inverter (HM / MI)
         uint8_t       ivRadioType = INV_RADIO_TYPE_UNKNOWN; // refers to used radio (nRF24 / CMT)
+        rf24_datarate_e radioDataRate = RF24_250KBPS;       // refers to datarate, only 1Gen MI uses 2MBPS
         cfgIv_t       *config = nullptr;                    // stored settings
         uint8_t       id = 0;                               // unique id
         uint8_t       type = INV_TYPE_1CH;                  // integer which refers to inverter type

--- a/src/hm/hmSystem.h
+++ b/src/hm/hmSystem.h
@@ -33,19 +33,22 @@ class HmSystem {
                 switch(iv->config->serial.b[4]) {
                     case 0x24: // HMS-500
                     case 0x22:
-                    case 0x21: iv->type = INV_TYPE_1CH;
+                    case 0x21:
+                    case 0x20: iv->type = INV_TYPE_1CH;
                         break;
 
                     case 0x25: // HMS-400 - 1 channel but payload like 2ch
 
                     case 0x44: // HMS-1000
                     case 0x42:
-                    case 0x41: iv->type = INV_TYPE_2CH;
+                    case 0x41:
+                    case 0x40: iv->type = INV_TYPE_2CH;
                         break;
 
                     case 0x64: // HMS-2000
                     case 0x62:
-                    case 0x61: iv->type = INV_TYPE_4CH;
+                    case 0x61:
+                    case 0x60: iv->type = INV_TYPE_4CH;
                         break;
 
                     default:
@@ -67,6 +70,9 @@ class HmSystem {
                 } else {  // MI 2nd Gen
                     iv->ivGen = IV_MI;
                     iv->ivRadioType = INV_RADIO_TYPE_NRF;
+                    if((iv->config->serial.b[4] & 0x01) == 0x00) { // MI 1st Gen -> uses 2MBPS data rate
+                        iv->radioDataRate = RF24_2MBPS;
+                    }
                 }
             } else if(iv->config->serial.b[5] == 0x13) {
                 iv->ivGen = IV_HMT;
@@ -100,7 +106,7 @@ class HmSystem {
             } else if(iv->config->serial.b[5] == 0x13)
                 DBGPRINT("HMT");
             else
-                DBGPRINT(((iv->config->serial.b[4] & 0x03) == 0x01) ? " (2nd Gen) " : " (3rd Gen) ");
+                DBGPRINT(((iv->config->serial.b[4] & 0x03) == 0x00) ? " (1st Gen) " : (((iv->config->serial.b[4] & 0x03) == 0x01) ? " (2nd Gen) " : " (3rd Gen) "));
 
             DBGPRINTLN(String(iv->config->serial.u64, HEX));
 


### PR DESCRIPTION
Protocol is the same as 2nd Gen MI but using 2MBPS data-rate, so data rate is changed before sending a message 
	
TODO: Improve success rate, now at 30%, possible changes:
- Adjust timing since messages at 2MBPS should arrive faster
- Verify default channel hopping behavior

Fixes #885 

<img width="864" height="2604" alt="Screenshot 2025-09-11 at 19-04-06 AHOY-DTU - Live" src="https://github.com/user-attachments/assets/1a0d67c7-1da6-4630-baf8-50c826c1cead" />
