### PR TITLE
Send Discovery Configuration on MQTT connect

### DIFF
--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -166,6 +166,7 @@ typedef struct {
     bool json;
     uint16_t interval;
     bool enableRetain;
+    bool sendConfigOnConnect;
 } cfgMqtt_t;
 
 typedef struct {
@@ -473,6 +474,7 @@ class settings {
             mCfg.mqtt.interval = 0; // off
             mCfg.mqtt.json = false; // off
             mCfg.mqtt.enableRetain = true;
+            mCfg.mqtt.sendConfigOnConnect = false;
 
             mCfg.inst.sendInterval       = SEND_INTERVAL;
             mCfg.inst.rstValsAtMidNight   = false;
@@ -728,6 +730,7 @@ class settings {
                 obj[F("json")]     = mCfg.mqtt.json;
                 obj[F("intvl")]    = mCfg.mqtt.interval;
                 obj[F("retain")]   = mCfg.mqtt.enableRetain;
+                obj[F("sendConfigOnConnect")] = mCfg.mqtt.sendConfigOnConnect;
 
             } else {
                 getVal<uint16_t>(obj, F("port"), &mCfg.mqtt.port);
@@ -739,6 +742,7 @@ class settings {
                 getChar(obj, F("pwd"), mCfg.mqtt.pwd, MQTT_PWD_LEN);
                 getChar(obj, F("topic"), mCfg.mqtt.topic, MQTT_TOPIC_LEN);
                 getVal<bool>(obj, F("retain"), &mCfg.mqtt.enableRetain);
+                getVal<bool>(obj, F("sendConfigOnConnect"), &mCfg.mqtt.sendConfigOnConnect);
             }
         }
 

--- a/src/publisher/pubMqtt.h
+++ b/src/publisher/pubMqtt.h
@@ -303,6 +303,7 @@ class PubMqtt {
                 subscribe(mVal.data());
             }
             subscribe(subscr[MQTT_SUBS_SET_TIME]);
+            sendDiscoveryConfig();
         }
 
         void onDisconnect(espMqttClientTypes::DisconnectReason reason) {

--- a/src/publisher/pubMqtt.h
+++ b/src/publisher/pubMqtt.h
@@ -303,7 +303,8 @@ class PubMqtt {
                 subscribe(mVal.data());
             }
             subscribe(subscr[MQTT_SUBS_SET_TIME]);
-            sendDiscoveryConfig();
+            if(mCfgMqtt->sendConfigOnConnect)
+                sendDiscoveryConfig();
         }
 
         void onDisconnect(espMqttClientTypes::DisconnectReason reason) {

--- a/src/web/RestApi.h
+++ b/src/web/RestApi.h
@@ -731,6 +731,7 @@ class RestApi {
             obj[F("json")]       = (bool) mConfig->mqtt.json;
             obj[F("interval")]   = String(mConfig->mqtt.interval);
             obj[F("retain")]     = (bool)mConfig->mqtt.enableRetain;
+            obj[F("sendConfigOnConnect")] = (bool)mConfig->mqtt.sendConfigOnConnect;
         }
 
         void getNtp(JsonObject obj) {

--- a/src/web/html/setup.html
+++ b/src/web/html/setup.html
@@ -245,7 +245,11 @@
                                 <div class="col-12 col-sm-9"><input type="number" name="mqttInterval" title="Invalid input" /></div>
                             </div>
                             <div class="row mb-3">
-                                <div class="col-12 col-sm-3 my-2">Discovery Config (homeassistant)</div>
+                                <div class="col-8 col-sm-3">Send Home Assistant discovery config on MQTT connect</div>
+                                <div class="col-4 col-sm-9"><input type="checkbox" name="sendConfigOnConnect"/></div>
+                            </div>
+                            <div class="row mb-3">
+                                <div class="col-12 col-sm-3 my-2">Force sending Home Assistant discovery config</div>
                                 <div class="col-12 col-sm-9">
                                     <input type="button" name="mqttDiscovery" id="mqttDiscovery" class="btn" value="{#BTN_SEND}" onclick="sendDiscoveryConfig()"/>
                                     <span id="apiResultMqtt"></span>
@@ -990,6 +994,7 @@
                     document.getElementsByName("mqtt"+i[0])[0].value = obj[i[1]];
                 document.getElementsByName("mqttJson")[0].checked = obj["json"];
                 document.getElementsByName("retain")[0].checked = obj.retain
+                document.getElementsByName("sendConfigOnConnect")[0].checked = obj["sendConfigOnConnect"];
             }
 
             function parseNtp(obj) {

--- a/src/web/html/setup.html
+++ b/src/web/html/setup.html
@@ -245,19 +245,16 @@
                                 <div class="col-12 col-sm-9"><input type="number" name="mqttInterval" title="Invalid input" /></div>
                             </div>
                             <div class="row mb-3">
-                                <div class="col-8 col-sm-3">Send Home Assistant discovery config on MQTT connect</div>
-                                <div class="col-4 col-sm-9"><input type="checkbox" name="sendConfigOnConnect"/></div>
+                                <div class="col-8 col-sm-3">{#RETAIN}</div>
+                                <div class="col-4 col-sm-9"><input type="checkbox" name="retain"/></div>
                             </div>
                             <div class="row mb-3">
-                                <div class="col-12 col-sm-3 my-2">Force sending Home Assistant discovery config</div>
-                                <div class="col-12 col-sm-9">
+                                <div class="col-8 col-sm-3">{#SEND_CONFIG_ON_CONNECT}</div>
+                                <div class="col-4 col-sm-3"><input type="checkbox" name="sendConfigOnConnect"/></div>
+                                <div class="col-10 col-sm-3">
                                     <input type="button" name="mqttDiscovery" id="mqttDiscovery" class="btn" value="{#BTN_SEND}" onclick="sendDiscoveryConfig()"/>
                                     <span id="apiResultMqtt"></span>
                                 </div>
-                            </div>
-                            <div class="row mb-3">
-                                <div class="col-8 col-sm-3">{#RETAIN}</div>
-                                <div class="col-4 col-sm-9"><input type="checkbox" name="retain"/></div>
                             </div>
                         </fieldset>
                     </div>

--- a/src/web/lang.json
+++ b/src/web/lang.json
@@ -495,8 +495,8 @@
                 },
                 {
                     "token": "BTN_SEND",
-                    "en": "send",
-                    "de": "senden"
+                    "en": "Force send",
+                    "de": "Senden erzwingen"
                 },
                 {
                     "token": "BTN_REBOOT_SUCCESSFUL_SAVE",
@@ -822,6 +822,11 @@
                     "token": "NO_NETWORK_FOUND",
                     "en": "no network found",
                     "de": "kein Netzwerk gefunden"
+                },
+                {
+                    "token": "SEND_CONFIG_ON_CONNECT",
+                    "en": "Send discovery config on MQTT connect",
+                    "de": "Discovery-Konfiguration beim MQTT-Verbindungsaufbau senden"
                 }
             ]
         },

--- a/src/web/web.h
+++ b/src/web/web.h
@@ -598,6 +598,7 @@ class Web {
             mConfig->mqtt.json = (request->arg("mqttJson") == "on");
             mConfig->mqtt.port = request->arg("mqttPort").toInt();
             mConfig->mqtt.interval = request->arg("mqttInterval").toInt();
+            mConfig->mqtt.sendConfigOnConnect = (request->arg("sendConfigOnConnect") == "on");
             mConfig->mqtt.enableRetain = (request->arg("retain") == "on");
 
             // serial console


### PR DESCRIPTION
This PR adds an option to send Home Assistant discovery configuration whenever a connection is established with the MQTT broker. This way, the end user can be sure that the MQTT broker, and therefore Home Assistant, will always have the current configuration of inverters and DTUs, even after restarting the Ahoy-DTU or MQTT broker.

For backward compatibility, the functionality is disabled by default, and it is still possible to manually trigger sending the configuration.

Here is a screenshot from the reworked MQTT web settings:
<img width="897" height="218" alt="obraz" src="https://github.com/user-attachments/assets/e7a46d24-bdc6-4b84-9984-bbae8ca7addf" />


This PR probably fixes #1715
