### PR TITLE
Send total YD and YT even when an inverter is inactive

### DIFF
--- a/src/publisher/pubMqttIvData.h
+++ b/src/publisher/pubMqttIvData.h
@@ -171,19 +171,20 @@ class PubMqttIvData {
                                     mTotal[3] += mIv->getValue(mPos, rec);
                                     break;
                             }
-                        } else if (mIv->GeneralConfig->rstValsAtMidNight) {
+                        } else if (mIv->GeneralConfig->rstValsAtMidNight && rec->ts > 0) {
                             // Inverter is OFF - use last stored YT/YD values for total calculation.
                             // It is safe to use them when values are reset at midnight.
+                            // Timestap check is to avoid wrong totals after restart (lower than before restart).
                             // This helps in having correct total values during daytime even when some inverters are OFF
                             switch (rec->assign[mPos].fieldId) {
                                 case FLD_YT:
-                                    DPRINT_IVID(DBG_DEBUG, mPos);
+                                    DPRINT_IVID(DBG_DEBUG, mIv->id);
                                     DBGPRINT(F("Inverter is OFF - Using last YT: "));
                                     DBGPRINTLN(String(mIv->getValue(mPos, rec)));
                                     mTotal[1] += mIv->getValue(mPos, rec);
                                     break;
                                 case FLD_YD: {
-                                    DPRINT_IVID(DBG_DEBUG, mPos);
+                                    DPRINT_IVID(DBG_DEBUG, mIv->id);
                                     DBGPRINT(F("Inverter is OFF - Using last YD: "));
                                     DBGPRINTLN(String(mIv->getValue(mPos, rec)));
                                     mTotal[2] += mIv->getValue(mPos, rec);

--- a/src/publisher/pubMqttIvData.h
+++ b/src/publisher/pubMqttIvData.h
@@ -172,16 +172,19 @@ class PubMqttIvData {
                                     break;
                             }
                         } else if (mIv->GeneralConfig->rstValsAtMidNight) {
+                            // Inverter is OFF - use last stored YT/YD values for total calculation.
+                            // It is safe to use them when values are reset at midnight.
+                            // This helps in having correct total values during daytime even when some inverters are OFF
                             switch (rec->assign[mPos].fieldId) {
                                 case FLD_YT:
-                                    DPRINT_IVID(DBG_INFO, mPos);
-                                    DBGPRINT(F("Inverter OFF - YT: "));
+                                    DPRINT_IVID(DBG_DEBUG, mPos);
+                                    DBGPRINT(F("Inverter is OFF - Using last YT: "));
                                     DBGPRINTLN(String(mIv->getValue(mPos, rec)));
                                     mTotal[1] += mIv->getValue(mPos, rec);
                                     break;
                                 case FLD_YD: {
-                                    DPRINT_IVID(DBG_INFO, mPos);
-                                    DBGPRINT(F("Inverter OFF - YD: "));
+                                    DPRINT_IVID(DBG_DEBUG, mPos);
+                                    DBGPRINT(F("Inverter is OFF - Using last YD: "));
                                     DBGPRINTLN(String(mIv->getValue(mPos, rec)));
                                     mTotal[2] += mIv->getValue(mPos, rec);
                                     break;

--- a/src/publisher/pubMqttIvData.h
+++ b/src/publisher/pubMqttIvData.h
@@ -171,8 +171,26 @@ class PubMqttIvData {
                                     mTotal[3] += mIv->getValue(mPos, rec);
                                     break;
                             }
-                        } else
+                        } else if (mIv->GeneralConfig->rstValsAtMidNight) {
+                            switch (rec->assign[mPos].fieldId) {
+                                case FLD_YT:
+                                    DPRINT_IVID(DBG_INFO, mPos);
+                                    DBGPRINT(F("Inverter OFF - YT: "));
+                                    DBGPRINTLN(String(mIv->getValue(mPos, rec)));
+                                    mTotal[1] += mIv->getValue(mPos, rec);
+                                    break;
+                                case FLD_YD: {
+                                    DPRINT_IVID(DBG_INFO, mPos);
+                                    DBGPRINT(F("Inverter OFF - YD: "));
+                                    DBGPRINTLN(String(mIv->getValue(mPos, rec)));
+                                    mTotal[2] += mIv->getValue(mPos, rec);
+                                    break;
+                                }
+                            }
+                        }
+                        else {
                             mAllTotalFound = false;
+                        }
                     }
                 }
 


### PR DESCRIPTION
When reset at midnight is enabled, total YD and YT are sent, even when one or more inverters are unreachable. This helps keep the total values updated in a system with many inverters, where it is more probable that one of them becomes offline (for example, due to communication issues).
To prevent incorrect total values after AhoyDTU reset, total values are sent only when all inverters have been seen (correct YD and YT received) at least once after the reset.

I wasn't sure whether it was safe to do the same when reset at sunrise or sunset is enabled, but if needed, this can be easily added.