### PR TITLE
Add units to interval descriptions in lang.json

### DIFF
--- a/src/web/lang.json
+++ b/src/web/lang.json
@@ -315,8 +315,8 @@
                 },
                 {
                     "token": "INTERVAL",
-                    "en": "Interval",
-                    "de": "Intervall"
+                    "en": "Interval [s]",
+                    "de": "Intervall [s]"
                 },
                 {
                     "token": "INV_RESET_MIDNIGHT",
@@ -420,8 +420,8 @@
                 },
                 {
                     "token": "MQTT_NOTE",
-                    "en": "Send Inverter data in a fixed interval, even if there is no change. A value of '0' disables the fixed interval. The data is published once it was successfully received from inverter. (default: 0)",
-                    "de": "Wechselrichterdaten in fixem Intervall schicken, auch wenn es keine &Auml;nderung gab. Ein Wert von '0' deaktiviert das fixe Intervall, die Wechselrichterdaten werden &uuml;bertragen, sobald neue zur Verf&uuml;gung stehen. (Standard: 0)"
+                    "en": "Send Inverter data in a fixed interval (in seconds), even if there is no change. A value of '0' disables the fixed interval. The data is published once it was successfully received from inverter. (default: 0)",
+                    "de": "Wechselrichterdaten in fixem Intervall (in Sekunden) schicken, auch wenn es keine &Auml;nderung gab. Ein Wert von '0' deaktiviert das fixe Intervall, die Wechselrichterdaten werden &uuml;bertragen, sobald neue zur Verf&uuml;gung stehen. (Standard: 0)"
                 },
                 {
                     "token": "RETAIN",


### PR DESCRIPTION
Fixed missing units. Users do not know what the unit is (seconds, minutes, milliseconds, or teddy bears). Updated language entries to include units in the interval descriptions.